### PR TITLE
feat: Unify plotting for quadrilateral and mixed meshes

### DIFF
--- a/src/fortfem_api.f90
+++ b/src/fortfem_api.f90
@@ -2072,7 +2072,7 @@ contains
         use fortplot, only: figure, xlabel, ylabel, &
                             fortplot_title => title, xlim, ylim, savefig
         use fortplot_figure, only: figure_t
-        type(mesh_t), intent(in) :: mesh
+        type(mesh_t), intent(inout) :: mesh
         character(len=*), intent(in), optional :: filename
         character(len=*), intent(in), optional :: title
         logical, intent(in), optional :: show_labels
@@ -2114,34 +2114,23 @@ contains
         ! Create figure
         call fig%initialize()
         
+        ! Ensure edge connectivity is available
+        if (.not. allocated(mesh%data%edges)) then
+            call mesh%data%build_connectivity()
+        end if
+        
         ! Allocate arrays for edge plotting  
         allocate(x_edges(2), y_edges(2))
         
-        ! Plot each edge separately to avoid connecting triangles
-        do e = 1, mesh%data%n_triangles
-            v1 = mesh%data%triangles(1, e)
-            v2 = mesh%data%triangles(2, e)
-            v3 = mesh%data%triangles(3, e)
+        ! Plot each edge separately to avoid spurious diagonals
+        do e = 1, mesh%data%n_edges
+            v1 = mesh%data%edges(1, e)
+            v2 = mesh%data%edges(2, e)
             
-            ! Edge 1: v1 to v2
             x_edges(1) = real(mesh%data%vertices(1, v1), 8)
             x_edges(2) = real(mesh%data%vertices(1, v2), 8)
             y_edges(1) = real(mesh%data%vertices(2, v1), 8)
             y_edges(2) = real(mesh%data%vertices(2, v2), 8)
-            call fig%add_plot(x_edges, y_edges)
-            
-            ! Edge 2: v2 to v3
-            x_edges(1) = real(mesh%data%vertices(1, v2), 8)
-            x_edges(2) = real(mesh%data%vertices(1, v3), 8)
-            y_edges(1) = real(mesh%data%vertices(2, v2), 8)
-            y_edges(2) = real(mesh%data%vertices(2, v3), 8)
-            call fig%add_plot(x_edges, y_edges)
-            
-            ! Edge 3: v3 to v1
-            x_edges(1) = real(mesh%data%vertices(1, v3), 8)
-            x_edges(2) = real(mesh%data%vertices(1, v1), 8)
-            y_edges(1) = real(mesh%data%vertices(2, v3), 8)
-            y_edges(2) = real(mesh%data%vertices(2, v1), 8)
             call fig%add_plot(x_edges, y_edges)
         end do
         

--- a/test/test_mesh_plotting.f90
+++ b/test/test_mesh_plotting.f90
@@ -12,6 +12,8 @@ program test_mesh_plotting
     call test_plot_function_exists()
     call test_simple_mesh_plot()
     call test_plot_with_options()
+    call test_quad_mesh_plot()
+    call test_mixed_mesh_plot()
     
     ! Summary
     write(*,*) ""
@@ -38,6 +40,66 @@ contains
         write(*,*) "  Testing basic plot interface..."
         call plot(mesh)  ! Should generate mesh plot
         write(*,*) "  ✓ plot(mesh) interface works"
+        
+        call end_test()
+    end subroutine
+    
+    subroutine test_quad_mesh_plot()
+        character(len=*), parameter :: test_name = "Quadrilateral Mesh Plot"
+        type(mesh_t) :: mesh
+        
+        call start_test(test_name)
+        
+        mesh = structured_quad_mesh(4, 3, 0.0_dp, 2.0_dp, 0.0_dp, 1.0_dp)
+        
+        write(*,*) "  Testing quadrilateral mesh plotting..."
+        call plot(mesh, filename="build/test_quad_mesh.png", &
+                  title="Structured Quad Mesh")
+        write(*,*) "  ✓ plot(quad mesh) works"
+        
+        call end_test()
+    end subroutine
+
+    subroutine test_mixed_mesh_plot()
+        character(len=*), parameter :: test_name = "Mixed Mesh Plot"
+        type(mesh_t) :: tri_mesh, quad_mesh, mixed_mesh
+        integer :: n_vertices, i
+        
+        call start_test(test_name)
+        
+        tri_mesh = unit_square_mesh(3)
+        quad_mesh = structured_quad_mesh(2, 2, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
+        
+        mixed_mesh%data%n_vertices = tri_mesh%data%n_vertices + quad_mesh%data%n_vertices
+        mixed_mesh%data%n_triangles = tri_mesh%data%n_triangles
+        mixed_mesh%data%n_quads = quad_mesh%data%n_quads
+        mixed_mesh%data%has_triangles = .true.
+        mixed_mesh%data%has_quads = .true.
+        mixed_mesh%data%has_mixed_elements = .true.
+        
+        allocate(mixed_mesh%data%vertices(2, mixed_mesh%data%n_vertices))
+        allocate(mixed_mesh%data%triangles(3, mixed_mesh%data%n_triangles))
+        allocate(mixed_mesh%data%quads(4, mixed_mesh%data%n_quads))
+        
+        mixed_mesh%data%vertices(:, 1:tri_mesh%data%n_vertices) = tri_mesh%data%vertices
+        mixed_mesh%data%triangles = tri_mesh%data%triangles
+        
+        n_vertices = tri_mesh%data%n_vertices
+        do i = 1, quad_mesh%data%n_vertices
+            mixed_mesh%data%vertices(:, n_vertices + i) = quad_mesh%data%vertices(:, i) + &
+                [1.0_dp, 0.0_dp]
+        end do
+        do i = 1, quad_mesh%data%n_quads
+            mixed_mesh%data%quads(:, i) = quad_mesh%data%quads(:, i) + n_vertices
+        end do
+        
+        call mixed_mesh%data%build_connectivity()
+        call mixed_mesh%data%find_boundary()
+        
+        write(*,*) "  Testing mixed tri/quad mesh plotting..."
+        call plot(mixed_mesh, filename="build/test_mixed_mesh.png", &
+                  title="Mixed Tri/Quad Mesh")
+        write(*,*) "  ✓ plot(mixed mesh) works"
         
         call end_test()
     end subroutine


### PR DESCRIPTION
### **User description**
Addresses issue #8 (Add support for more element geometries) by completing the plotting and API integration for quadrilateral and mixed meshes:

- Extend `plot_mesh` in `src/fortfem_api.f90` to draw from the generic `edges` connectivity, so it now supports pure triangular, pure quadrilateral, and mixed tri/quad meshes without spurious diagonals.
- Ensure edge connectivity is available inside `plot_mesh` by calling `mesh%data%build_connectivity()` when needed.
- Add two new tests in `test/test_mesh_plotting.f90`: `test_quad_mesh_plot` (for `structured_quad_mesh`) and `test_mixed_mesh_plot` (for a simple mixed tri/quad mesh), each producing PNG output under `build/` (`build/test_quad_mesh.png` and `build/test_mixed_mesh.png`) for visual regression.

All tests pass locally with `fpm test`, and the new visuals demonstrate correct rendering of quadrilateral and mixed meshes.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactor `plot_mesh` to use generic edge connectivity instead of triangle-specific logic

- Support plotting of quadrilateral and mixed tri/quad meshes without spurious diagonals

- Add automatic edge connectivity building when needed inside `plot_mesh`

- Add two new test cases for quad and mixed mesh plotting with PNG output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Triangle/Quad/Mixed Mesh"] -->|"plot_mesh"| B["Build Connectivity"]
  B -->|"Iterate edges"| C["Plot Generic Edges"]
  C -->|"Output"| D["PNG Visualization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortfem_api.f90</strong><dd><code>Refactor plot_mesh to use generic edge connectivity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/fortfem_api.f90

<ul><li>Changed <code>mesh</code> parameter from <code>intent(in)</code> to <code>intent(inout)</code> to allow <br>connectivity building<br> <li> Added automatic edge connectivity building via <br><code>mesh%data%build_connectivity()</code> when edges not allocated<br> <li> Replaced triangle-specific edge extraction with generic <br><code>mesh%data%edges</code> iteration<br> <li> Removed hardcoded three-edge-per-triangle logic, now supports <br>arbitrary element types</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/20/files#diff-8643d60ce359bfda1bc7f10075820b1acd9b0174cf41d065371788abd44f40be">+10/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_mesh_plotting.f90</strong><dd><code>Add quad and mixed mesh plotting tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_mesh_plotting.f90

<ul><li>Added <code>test_quad_mesh_plot()</code> test for structured quadrilateral mesh <br>visualization<br> <li> Added <code>test_mixed_mesh_plot()</code> test for combined triangular and <br>quadrilateral mesh<br> <li> Both tests generate PNG output files for visual regression testing<br> <li> Mixed mesh test constructs a hybrid mesh by combining triangle and <br>quad meshes with offset vertices</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/20/files#diff-86e029651586688c38acdd1518fa4aa15d40e6195c6b7ddf33930642ac4abbe3">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

