### PR TITLE
fix: Clean square boundary mesh and enable quad solution plots

### DIFF
--- a/test/test_quadrilateral_elements.f90
+++ b/test/test_quadrilateral_elements.f90
@@ -24,6 +24,7 @@ program test_quadrilateral_elements
     call test_q1_boundary_conditions()
     call test_q1_convergence_rates()
     call test_q1_performance()
+    call test_q1_solution_plot()
     
     call check_summary("Quadrilateral Elements")
 
@@ -417,6 +418,34 @@ contains
         write(*,*) "   Q1 performance comparison: all tests passed"
         write(*,*) "   Assembly time ratio (quad/tri):", performance_ratio
     end subroutine test_q1_performance
+
+    ! Test plotting of a solution on a quadrilateral mesh
+    subroutine test_q1_solution_plot()
+        type(mesh_t) :: quad_mesh
+        type(function_space_t) :: Vh
+        type(function_t) :: uh
+        integer :: i
+        real(dp) :: x, y
+        real(dp), parameter :: pi = acos(-1.0_dp)
+        
+        quad_mesh = structured_quad_mesh(8, 8, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
+        Vh = function_space(quad_mesh, "Lagrange", 1)
+        uh = function(Vh)
+        
+        do i = 1, Vh%ndof
+            x = quad_mesh%data%vertices(1, i)
+            y = quad_mesh%data%vertices(2, i)
+            uh%values(i) = sin(pi * x) * sin(pi * y)
+        end do
+        
+        call check_condition(allocated(uh%values), &
+            "Q1 solution plot: values allocated")
+        
+        call plot(uh, filename="build/quad_solution.png", &
+                  title="Q1 quadrilateral solution")
+        
+        write(*,*) "   Q1 quad solution plot: generated build/quad_solution.png"
+    end subroutine test_q1_solution_plot
 
     ! Helper functions for Q1 elements
 


### PR DESCRIPTION
### **User description**
This PR tightens up the visuals and quadrilateral support you asked for:

- **Square boundary mesh:**
  - Detects simple axis-aligned rectangular boundaries in `mesh_2d_t%create_from_boundary` and routes them through `create_rectangular` instead of the generic Delaunay backend. The `test_square_boundary_mesh` now produces a structured 5×5 unit square mesh with 32 triangles and no overlapping or crossing lines.

- **Quadrilateral solution plotting:**
  - Adds `interpolate_quad_to_grid` in `fortfem_api` to perform true Q1 bilinear interpolation on structured quads when plotting scalar functions.
  - Extends `plot_function_scalar` to choose between triangular interpolation (`interpolate_to_grid`) and quadrilateral interpolation (`interpolate_quad_to_grid`) based on the mesh content.
  - Adds a new test `test_q1_solution_plot` in `test/test_quadrilateral_elements.f90` that builds a structured quad mesh, defines `u(x,y) = sin(pi x) sin(pi y)` at the Q1 DOFs, and plots it to `build/quad_solution.png` with the black mesh overlay.

- **Visual outputs:**
  - Updated PNG set now includes:
    - `build/test_square_boundary_mesh.png` as a tidy structured square mesh (no overlapping lines).
    - `build/quad_solution.png` as a quadrilateral solution plot with mesh overlay.

All tests pass locally with `fpm test`.


___

### **PR Type**
Enhancement


___

### **Description**
- Detects axis-aligned rectangular boundaries and routes through structured mesh creation

- Adds Q1 bilinear interpolation for quadrilateral mesh solution plotting

- Extends plot_function_scalar to choose interpolation based on mesh type

- Adds test_q1_solution_plot to verify quad solution visualization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Boundary Input"] --> B{"Axis-aligned\nRectangle?"}
  B -->|Yes| C["create_rectangular"]
  B -->|No| D["Triangulate"]
  C --> E["Structured Quad Mesh"]
  D --> F["Triangular Mesh"]
  E --> G["interpolate_quad_to_grid"]
  F --> H["interpolate_to_grid"]
  G --> I["Solution Plot"]
  H --> I
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortfem_api.f90</strong><dd><code>Add quadrilateral bilinear interpolation for plotting</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/fortfem_api.f90

<ul><li>Modified plot_function_scalar to conditionally call <br>interpolate_to_grid or interpolate_quad_to_grid based on mesh type<br> <li> Added new subroutine interpolate_quad_to_grid implementing Q1 bilinear <br>interpolation for structured quads<br> <li> Performs reference element mapping and evaluates shape functions at <br>grid points<br> <li> Falls back to nearest neighbor interpolation if point not found in any <br>quad</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/21/files#diff-8643d60ce359bfda1bc7f10075820b1acd9b0174cf41d065371788abd44f40be">+75/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mesh_2d.f90</strong><dd><code>Detect and handle rectangular boundary meshes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mesh/mesh_2d.f90

<ul><li>Added rectangle detection logic in create_from_boundary to identify <br>axis-aligned rectangular boundaries<br> <li> Checks if all boundary points lie on rectangle edges within tolerance<br> <li> Routes detected rectangles to create_rectangular for structured mesh <br>generation<br> <li> Falls back to Delaunay triangulation for non-rectangular boundaries</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/21/files#diff-34380a5052ebeaf141f72780fee922a224b00e660aa39dd9e06f1e8420ec393c">+36/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_quadrilateral_elements.f90</strong><dd><code>Add quadrilateral solution plot test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_quadrilateral_elements.f90

<ul><li>Added new test subroutine test_q1_solution_plot to verify <br>quadrilateral solution plotting<br> <li> Creates 8×8 structured quad mesh on unit square domain<br> <li> Defines test function u(x,y) = sin(π x) sin(π y) at Q1 DOFs<br> <li> Generates output plot to build/quad_solution.png and verifies values <br>allocation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/21/files#diff-8b86e41af4b0173365f0e7f316a6506dd0d5b1e295c062f6510eb895812fa3ff">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

