### PR TITLE
Poisson on quads and L-shape Delaunay example

### DIFF
--- a/src/basis/basis_q1_quad_2d.f90
+++ b/src/basis/basis_q1_quad_2d.f90
@@ -1,0 +1,82 @@
+module basis_q1_quad_2d_module
+    use fortfem_kinds, only: dp
+    implicit none
+    private
+
+    public :: q1_shape_functions
+    public :: q1_shape_derivatives
+    public :: q1_jacobian
+    public :: q1_reference_to_physical
+
+contains
+
+    pure subroutine q1_shape_functions(xi, eta, N)
+        real(dp), intent(in) :: xi, eta
+        real(dp), intent(out) :: N(4)
+        ! Q1 bilinear shape functions on reference square [-1,1] x [-1,1]
+        N(1) = 0.25_dp * (1.0_dp - xi) * (1.0_dp - eta)
+        N(2) = 0.25_dp * (1.0_dp + xi) * (1.0_dp - eta)
+        N(3) = 0.25_dp * (1.0_dp + xi) * (1.0_dp + eta)
+        N(4) = 0.25_dp * (1.0_dp - xi) * (1.0_dp + eta)
+    end subroutine q1_shape_functions
+
+    pure subroutine q1_shape_derivatives(xi, eta, dN_dxi, dN_deta)
+        real(dp), intent(in) :: xi, eta
+        real(dp), intent(out) :: dN_dxi(4), dN_deta(4)
+
+        dN_dxi(1) = -0.25_dp * (1.0_dp - eta)
+        dN_dxi(2) =  0.25_dp * (1.0_dp - eta)
+        dN_dxi(3) =  0.25_dp * (1.0_dp + eta)
+        dN_dxi(4) = -0.25_dp * (1.0_dp + eta)
+
+        dN_deta(1) = -0.25_dp * (1.0_dp - xi)
+        dN_deta(2) = -0.25_dp * (1.0_dp + xi)
+        dN_deta(3) =  0.25_dp * (1.0_dp + xi)
+        dN_deta(4) =  0.25_dp * (1.0_dp - xi)
+    end subroutine q1_shape_derivatives
+
+    pure subroutine q1_jacobian(xi, eta, coords, jac, det_jac, inv_jac, success)
+        real(dp), intent(in) :: xi, eta
+        real(dp), intent(in) :: coords(2,4)
+        real(dp), intent(out) :: jac(2,2)
+        real(dp), intent(out) :: det_jac
+        real(dp), intent(out) :: inv_jac(2,2)
+        logical, intent(out) :: success
+
+        real(dp) :: dN_dxi(4), dN_deta(4)
+
+        call q1_shape_derivatives(xi, eta, dN_dxi, dN_deta)
+
+        ! Jacobian of mapping x(xi,eta) = sum_i N_i(xi,eta) * x_i
+        jac(1,1) = sum(dN_dxi  * coords(1,:))   ! dx/dxi
+        jac(1,2) = sum(dN_deta * coords(1,:))   ! dx/deta
+        jac(2,1) = sum(dN_dxi  * coords(2,:))   ! dy/dxi
+        jac(2,2) = sum(dN_deta * coords(2,:))   ! dy/deta
+
+        det_jac = jac(1,1) * jac(2,2) - jac(1,2) * jac(2,1)
+
+        success = abs(det_jac) > 1.0e-12_dp
+        if (success) then
+            inv_jac(1,1) =  jac(2,2) / det_jac
+            inv_jac(1,2) = -jac(1,2) / det_jac
+            inv_jac(2,1) = -jac(2,1) / det_jac
+            inv_jac(2,2) =  jac(1,1) / det_jac
+        else
+            inv_jac = 0.0_dp
+        end if
+    end subroutine q1_jacobian
+
+    pure subroutine q1_reference_to_physical(xi_ref, eta_ref, coords, x_phys, y_phys)
+        real(dp), intent(in) :: xi_ref, eta_ref
+        real(dp), intent(in) :: coords(2,4)
+        real(dp), intent(out) :: x_phys, y_phys
+
+        real(dp) :: N(4)
+
+        call q1_shape_functions(xi_ref, eta_ref, N)
+        x_phys = sum(N * coords(1,:))
+        y_phys = sum(N * coords(2,:))
+    end subroutine q1_reference_to_physical
+
+end module basis_q1_quad_2d_module
+

--- a/test/test_lshape_mesh_plot.f90
+++ b/test/test_lshape_mesh_plot.f90
@@ -1,0 +1,36 @@
+program test_lshape_mesh_plot
+    use fortfem_kinds, only: dp
+    use fortfem_api, only: mesh_t, boundary_t, l_shape_boundary,          &
+        mesh_from_boundary, plot
+    use check, only: check_condition, check_summary
+    implicit none
+
+    type(boundary_t) :: boundary
+    type(mesh_t) :: mesh
+    integer :: n_boundary_vertices
+
+    write(*,*) "Testing L-shape boundary Delaunay mesh and plotting..."
+
+    boundary = l_shape_boundary(1.0_dp, 24)
+    mesh = mesh_from_boundary(boundary, resolution=0.08_dp)
+
+    n_boundary_vertices = count(mesh%data%is_boundary_vertex)
+
+    call check_condition(mesh%data%n_vertices > 0, &
+        "L-shape mesh: positive vertex count")
+    call check_condition(mesh%data%n_triangles > 0, &
+        "L-shape mesh: positive triangle count")
+    call check_condition(mesh%data%n_quads == 0, &
+        "L-shape mesh: pure triangular Delaunay mesh")
+    call check_condition(n_boundary_vertices > 0, &
+        "L-shape mesh: boundary vertices identified")
+
+    call plot(mesh, filename="build/test_lshape_boundary_mesh.png", &
+              title="L-shape Delaunay mesh")
+
+    write(*,*) "   L-shape Delaunay plot: generated build/test_lshape_boundary_mesh.png"
+
+    call check_summary("L-shape Delaunay Mesh Plot")
+
+end program test_lshape_mesh_plot
+

--- a/test/test_poisson_quads.f90
+++ b/test/test_poisson_quads.f90
@@ -1,0 +1,174 @@
+program test_poisson_quads
+    use fortfem_kinds, only: dp
+    use fortfem_api, only: mesh_t, function_space_t, trial_function_t,     &
+        test_function_t, function_t, dirichlet_bc_t, form_expr_t,          &
+        unit_square_mesh, structured_quad_mesh, function_space,            &
+        trial_function, test_function, constant, dirichlet_bc,             &
+        function, inner, grad, dx, solve, plot, operator(*), operator(==)
+    use check, only: check_condition, check_summary
+    implicit none
+
+    write(*,*) "Testing Poisson solver on Q1 quadrilateral meshes..."
+
+    call test_poisson_quads_basic()
+    call test_poisson_quads_vs_triangles()
+    call test_poisson_quads_plot()
+
+    call check_summary("Poisson on Quadrilateral Meshes")
+
+contains
+
+    subroutine test_poisson_quads_basic()
+        type(mesh_t) :: quad_mesh
+        type(function_space_t) :: Vh_q
+        type(trial_function_t) :: u_q
+        type(test_function_t) :: v_q
+        type(function_t) :: f_q, uh_q
+        type(dirichlet_bc_t) :: bc_q
+        type(form_expr_t) :: a_q, L_q
+        real(dp) :: max_val, max_interior, center_val
+        real(dp) :: x, y, min_dist, dist
+        integer :: i, center_node
+        logical :: is_boundary
+
+        quad_mesh = structured_quad_mesh(8, 8, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
+        Vh_q = function_space(quad_mesh, "Lagrange", 1)
+
+        u_q = trial_function(Vh_q)
+        v_q = test_function(Vh_q)
+        f_q = constant(1.0_dp)
+
+        a_q = inner(grad(u_q), grad(v_q)) * dx
+        L_q = f_q * v_q * dx
+
+        bc_q = dirichlet_bc(Vh_q, 0.0_dp)
+        uh_q = function(Vh_q)
+
+        call solve(a_q == L_q, uh_q, bc_q)
+
+        ! Basic sanity checks on solution
+        max_val = maxval(uh_q%values)
+        max_interior = 0.0_dp
+        min_dist = huge(1.0_dp)
+        center_node = 1
+
+        do i = 1, Vh_q%ndof
+            is_boundary = quad_mesh%data%is_boundary_vertex(i)
+            x = quad_mesh%data%vertices(1, i)
+            y = quad_mesh%data%vertices(2, i)
+
+            if (is_boundary) then
+                call check_condition(abs(uh_q%values(i)) < 1.0e-12_dp, &
+                    "Quad Poisson: boundary value approximately zero")
+            else
+                max_interior = max(max_interior, uh_q%values(i))
+                dist = (x - 0.5_dp)**2 + (y - 0.5_dp)**2
+                if (dist < min_dist) then
+                    min_dist = dist
+                    center_node = i
+                end if
+            end if
+        end do
+
+        center_val = uh_q%values(center_node)
+
+        call check_condition(max_interior > 0.0_dp, &
+            "Quad Poisson: interior solution positive")
+        call check_condition(max_interior < 0.5_dp, &
+            "Quad Poisson: interior solution bounded")
+        call check_condition(abs(max_val - max_interior) < 1.0e-10_dp, &
+            "Quad Poisson: maximum attained in interior")
+        call check_condition(center_val > 0.8_dp * max_interior, &
+            "Quad Poisson: maximum located near center")
+
+        write(*,*) "   Quad Poisson basic: max =", max_interior
+        write(*,*) "   Quad Poisson basic: center node =", center_node
+        write(*,*) "   Quad Poisson basic: center value =", center_val
+    end subroutine test_poisson_quads_basic
+
+    subroutine test_poisson_quads_vs_triangles()
+        type(mesh_t) :: quad_mesh, tri_mesh
+        type(function_space_t) :: Vh_q, Vh_t
+        type(trial_function_t) :: u_q, u_t
+        type(test_function_t) :: v_q, v_t
+        type(function_t) :: f_q, f_t, uh_q, uh_t
+        type(dirichlet_bc_t) :: bc_q, bc_t
+        type(form_expr_t) :: a_q, L_q, a_t, L_t
+        real(dp) :: max_q, max_t, rel_diff
+
+        quad_mesh = structured_quad_mesh(8, 8, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
+        tri_mesh = unit_square_mesh(8)
+
+        Vh_q = function_space(quad_mesh, "Lagrange", 1)
+        Vh_t = function_space(tri_mesh, "Lagrange", 1)
+
+        u_q = trial_function(Vh_q)
+        v_q = test_function(Vh_q)
+        f_q = constant(1.0_dp)
+        a_q = inner(grad(u_q), grad(v_q)) * dx
+        L_q = f_q * v_q * dx
+        bc_q = dirichlet_bc(Vh_q, 0.0_dp)
+        uh_q = function(Vh_q)
+        call solve(a_q == L_q, uh_q, bc_q)
+
+        u_t = trial_function(Vh_t)
+        v_t = test_function(Vh_t)
+        f_t = constant(1.0_dp)
+        a_t = inner(grad(u_t), grad(v_t)) * dx
+        L_t = f_t * v_t * dx
+        bc_t = dirichlet_bc(Vh_t, 0.0_dp)
+        uh_t = function(Vh_t)
+        call solve(a_t == L_t, uh_t, bc_t)
+
+        max_q = maxval(uh_q%values)
+        max_t = maxval(uh_t%values)
+
+        if (max_t > 0.0_dp) then
+            rel_diff = abs(max_q - max_t) / max_t
+        else
+            rel_diff = 0.0_dp
+        end if
+
+        call check_condition(max_q > 0.0_dp .and. max_t > 0.0_dp, &
+            "Quad vs Tri Poisson: positive maxima")
+        call check_condition(rel_diff < 0.2_dp, &
+            "Quad vs Tri Poisson: maxima reasonably close")
+
+        write(*,*) "   Quad vs Tri: max_quad =", max_q, " max_tri =", max_t
+        write(*,*) "   Quad vs Tri: relative difference =", rel_diff
+    end subroutine test_poisson_quads_vs_triangles
+
+    subroutine test_poisson_quads_plot()
+        type(mesh_t) :: quad_mesh
+        type(function_space_t) :: Vh_q
+        type(trial_function_t) :: u_q
+        type(test_function_t) :: v_q
+        type(function_t) :: f_q, uh_q
+        type(dirichlet_bc_t) :: bc_q
+        type(form_expr_t) :: a_q, L_q
+
+        quad_mesh = structured_quad_mesh(12, 12, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
+        Vh_q = function_space(quad_mesh, "Lagrange", 1)
+
+        u_q = trial_function(Vh_q)
+        v_q = test_function(Vh_q)
+        f_q = constant(1.0_dp)
+
+        a_q = inner(grad(u_q), grad(v_q)) * dx
+        L_q = f_q * v_q * dx
+
+        bc_q = dirichlet_bc(Vh_q, 0.0_dp)
+        uh_q = function(Vh_q)
+
+        call solve(a_q == L_q, uh_q, bc_q)
+
+        call plot(uh_q, filename="build/poisson_quads_solution.png", &
+                  title="Poisson solution on Q1 quadrilateral mesh")
+
+        call check_condition(any(uh_q%values /= 0.0_dp), &
+            "Quad Poisson plot: non-trivial solution plotted")
+
+        write(*,*) "   Quad Poisson plot: generated build/poisson_quads_solution.png"
+    end subroutine test_poisson_quads_plot
+
+end program test_poisson_quads

--- a/test/test_quadrilateral_elements.f90
+++ b/test/test_quadrilateral_elements.f90
@@ -1,6 +1,8 @@
 program test_quadrilateral_elements
     use fortfem_kinds
     use fortfem_api
+    use basis_q1_quad_2d_module, only: q1_shape_functions, q1_shape_derivatives, &
+                                        q1_jacobian, q1_reference_to_physical
     use check
     implicit none
 
@@ -446,68 +448,6 @@ contains
         
         write(*,*) "   Q1 quad solution plot: generated build/quad_solution.png"
     end subroutine test_q1_solution_plot
-
-    ! Helper functions for Q1 elements
-
-    subroutine q1_shape_functions(xi, eta, N)
-        real(dp), intent(in) :: xi, eta
-        real(dp), intent(out) :: N(4)
-        ! Q1 bilinear shape functions
-        N(1) = 0.25_dp * (1.0_dp - xi) * (1.0_dp - eta)
-        N(2) = 0.25_dp * (1.0_dp + xi) * (1.0_dp - eta)
-        N(3) = 0.25_dp * (1.0_dp + xi) * (1.0_dp + eta)
-        N(4) = 0.25_dp * (1.0_dp - xi) * (1.0_dp + eta)
-    end subroutine q1_shape_functions
-
-    subroutine q1_shape_derivatives(xi, eta, dN_dxi, dN_deta)
-        real(dp), intent(in) :: xi, eta
-        real(dp), intent(out) :: dN_dxi(4), dN_deta(4)
-        ! Derivatives of Q1 shape functions
-        dN_dxi(1) = -0.25_dp * (1.0_dp - eta)
-        dN_dxi(2) =  0.25_dp * (1.0_dp - eta)
-        dN_dxi(3) =  0.25_dp * (1.0_dp + eta)
-        dN_dxi(4) = -0.25_dp * (1.0_dp + eta)
-        
-        dN_deta(1) = -0.25_dp * (1.0_dp - xi)
-        dN_deta(2) = -0.25_dp * (1.0_dp + xi)
-        dN_deta(3) =  0.25_dp * (1.0_dp + xi)
-        dN_deta(4) =  0.25_dp * (1.0_dp - xi)
-    end subroutine q1_shape_derivatives
-
-    subroutine q1_jacobian(xi, eta, coords, jac, det_jac, inv_jac, success)
-        real(dp), intent(in) :: xi, eta, coords(2,4)
-        real(dp), intent(out) :: jac(2,2), det_jac, inv_jac(2,2)
-        logical, intent(out) :: success
-        real(dp) :: dN_dxi(4), dN_deta(4)
-        
-        call q1_shape_derivatives(xi, eta, dN_dxi, dN_deta)
-        
-        ! Compute Jacobian
-        jac(1,1) = sum(dN_dxi * coords(1,:))    ! dx/dxi
-        jac(1,2) = sum(dN_deta * coords(1,:))   ! dx/deta
-        jac(2,1) = sum(dN_dxi * coords(2,:))    ! dy/dxi
-        jac(2,2) = sum(dN_deta * coords(2,:))   ! dy/deta
-        
-        det_jac = jac(1,1) * jac(2,2) - jac(1,2) * jac(2,1)
-        
-        success = abs(det_jac) > 1.0e-12_dp
-        if (success) then
-            inv_jac(1,1) =  jac(2,2) / det_jac
-            inv_jac(1,2) = -jac(1,2) / det_jac
-            inv_jac(2,1) = -jac(2,1) / det_jac
-            inv_jac(2,2) =  jac(1,1) / det_jac
-        end if
-    end subroutine q1_jacobian
-
-    subroutine q1_reference_to_physical(xi_ref, eta_ref, coords, x_phys, y_phys)
-        real(dp), intent(in) :: xi_ref, eta_ref, coords(2,4)
-        real(dp), intent(out) :: x_phys, y_phys
-        real(dp) :: N(4)
-        
-        call q1_shape_functions(xi_ref, eta_ref, N)
-        x_phys = sum(N * coords(1,:))
-        y_phys = sum(N * coords(2,:))
-    end subroutine q1_reference_to_physical
 
     function integrate_over_quad(func, coords, nq) result(integral)
         procedure(test_function_interface) :: func


### PR DESCRIPTION
### **User description**
Implement Q1 Poisson solve on quadrilateral meshes, add manufactured tests and plots, and add an L-shape Delaunay mesh regression test with PNG output.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Q1 bilinear shape functions module for quadrilateral elements

- Implement Poisson solver on quadrilateral meshes with Gauss quadrature

- Refactor Laplacian assembly to support both triangles and quads

- Add comprehensive tests for Poisson on quads and L-shape Delaunay mesh

- Improve mesh plotting to use edge connectivity instead of triangle enumeration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Q1 Basis Module<br/>basis_q1_quad_2d.f90"] --> B["Quad Assembly<br/>assemble_laplacian_quads"]
  B --> C["Laplacian System<br/>assemble_laplacian_system"]
  D["Triangle Assembly<br/>assemble_laplacian_triangles"] --> C
  C --> E["Poisson Solver<br/>solve"]
  E --> F["Visualization<br/>plot"]
  G["Edge Connectivity<br/>build_connectivity"] --> F
  H["Test Poisson Quads<br/>test_poisson_quads.f90"] --> E
  I["Test L-shape Mesh<br/>test_lshape_mesh_plot.f90"] --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>basis_q1_quad_2d.f90</strong><dd><code>Q1 quadrilateral basis functions module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/basis/basis_q1_quad_2d.f90

<ul><li>New module implementing Q1 bilinear shape functions on reference <br>square [-1,1]²<br> <li> Provides shape function evaluations and derivatives at reference <br>coordinates<br> <li> Implements Jacobian computation with determinant and inverse for <br>coordinate transformations<br> <li> Includes reference-to-physical coordinate mapping for quadrilateral <br>elements</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/22/files#diff-479017115fa0464a0a2adc9b6d89079b40c56f2ff6d3e0bdacd2945ff4dc4188">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fortfem_api.f90</strong><dd><code>Laplacian assembly for quads and edge-based plotting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/fortfem_api.f90

<ul><li>Refactor <code>assemble_laplacian_system</code> to delegate triangle and quad <br>assembly to separate subroutines<br> <li> Extract triangle assembly into <code>assemble_laplacian_triangles</code> with <br>improved variable naming (bx, by instead of b, c)<br> <li> Implement <code>assemble_laplacian_quads</code> using 2×2 Gauss quadrature with Q1 <br>basis functions<br> <li> Update mesh plotting to use pre-built edge connectivity instead of <br>manually enumerating triangle edges<br> <li> Simplify plot_function_scalar by calling <code>build_connectivity()</code> and <br>iterating over edges</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/22/files#diff-8643d60ce359bfda1bc7f10075820b1acd9b0174cf41d065371788abd44f40be">+149/-79</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_poisson_quads.f90</strong><dd><code>Poisson solver tests on quadrilateral meshes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_poisson_quads.f90

<ul><li>New test program for Poisson solver on Q1 quadrilateral meshes<br> <li> Test basic Poisson solve on 8×8 structured quad mesh with unit forcing <br>and zero boundary conditions<br> <li> Compare quad and triangle solutions on equivalent domains to verify <br>consistency<br> <li> Generate visualization of Poisson solution on 12×12 quad mesh<br> <li> Verify boundary conditions, interior positivity, and solution bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/22/files#diff-939ad11fa27155b24e6979502f1d5ecb7ba16121295d553e80bfb4186facf0b0">+174/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_lshape_mesh_plot.f90</strong><dd><code>L-shape Delaunay mesh regression test with plotting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_lshape_mesh_plot.f90

<ul><li>New test program for L-shape Delaunay mesh generation and <br>visualization<br> <li> Create L-shape boundary with 24 vertices and generate Delaunay <br>triangulation at 0.08 resolution<br> <li> Verify mesh properties (positive vertex/triangle counts, pure <br>triangular mesh)<br> <li> Generate PNG plot of L-shape Delaunay mesh<br> <li> Validate boundary vertex identification</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/22/files#diff-8bb897c4d63a7d908eeb0d160bc500dc73ab1bb670f8375fe7808a68e8656ecc">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_quadrilateral_elements.f90</strong><dd><code>Consolidate Q1 basis functions into shared module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_quadrilateral_elements.f90

<ul><li>Add module import for Q1 basis functions from new <br><code>basis_q1_quad_2d_module</code><br> <li> Remove duplicate Q1 shape function, derivative, Jacobian, and <br>coordinate mapping implementations<br> <li> Consolidate basis function code into centralized module for <br>reusability</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfem/pull/22/files#diff-8b86e41af4b0173365f0e7f316a6506dd0d5b1e295c062f6510eb895812fa3ff">+2/-62</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

