### PR TITLE
[fmt] format all sources with fo fmt native style

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -1,10 +1,10 @@
 program main
-  use fortfem_api
-  implicit none
+    use fortfem_api
+    implicit none
 
-  print *, "FortFEM - Modern Fortran Finite Element Library"
-  print *, "Clean FEniCS-style API for natural mathematical notation"
-  print *, ""
-  print *, "Run examples with: fpm run --example simple_poisson"
-  print *, "Run tests with: fpm test"
+    print *, "FortFEM - Modern Fortran Finite Element Library"
+    print *, "Clean FEniCS-style API for natural mathematical notation"
+    print *, ""
+    print *, "Run examples with: fpm run --example simple_poisson"
+    print *, "Run tests with: fpm test"
 end program main

--- a/benchmark/fortfem_mesh_benchmark.f90
+++ b/benchmark/fortfem_mesh_benchmark.f90
@@ -8,45 +8,45 @@ program fortfem_mesh_benchmark
     integer :: mesh_sizes(n_sizes) = [5, 10, 15, 20, 25, 30]
     real(dp) :: fortfem_times(n_sizes)
     integer :: fortfem_vertices(n_sizes), fortfem_triangles(n_sizes)
-    
+
     type(mesh_t) :: mesh
     real(dp) :: start_time, end_time
     integer :: i, n
-    
+
     write(*,*) "=== FortFEM Mesh Generation Benchmark ==="
     write(*,*) ""
-    
+
     ! Run benchmark for each mesh size
     do i = 1, n_sizes
         n = mesh_sizes(i)
-        
+
         write(*,'(A,I0,A,I0,A)') "Testing ", n, "x", n, " mesh:"
-        
+
         ! Time FortFEM mesh generation
         call cpu_time(start_time)
         mesh = unit_square_mesh(n)
         call cpu_time(end_time)
-        
+
         fortfem_times(i) = end_time - start_time
         fortfem_vertices(i) = mesh%data%n_vertices
         fortfem_triangles(i) = mesh%data%n_triangles
-        
+
         write(*,'(A,I0,A,I0,A,ES10.3,A)') "  FortFEM: ", fortfem_vertices(i), &
-               " vertices, ", fortfem_triangles(i), " triangles, ", fortfem_times(i), "s"
+            " vertices, ", fortfem_triangles(i), " triangles, ", fortfem_times(i), "s"
     end do
-    
+
     write(*,*) ""
     write(*,*) "=== Benchmark Results ==="
     write(*,*) "Size	FortFEM_vertices	FortFEM_triangles	FortFEM_time(s)"
-    
+
     do i = 1, n_sizes
         write(*,'(I0,A,I0,A,I0,A,ES10.3)') mesh_sizes(i), char(9), fortfem_vertices(i), &
-               char(9), char(9), fortfem_triangles(i), char(9), char(9), fortfem_times(i)
+            char(9), char(9), fortfem_triangles(i), char(9), char(9), fortfem_times(i)
     end do
-    
+
     ! Save results for comparison
     call save_benchmark_results()
-    
+
     write(*,*) ""
     write(*,*) "FortFEM benchmark completed."
     write(*,*) "Results saved to fortfem_benchmark_results.dat"
@@ -54,27 +54,27 @@ program fortfem_mesh_benchmark
     write(*,*) "To compare with FreeFEM:"
     write(*,*) "1. Run: FreeFem++ benchmark/mesh_comparison.edp"
     write(*,*) "2. Compare fortfem_benchmark_results.dat with freefem_benchmark_results.dat"
-    
+
 contains
 
     subroutine save_benchmark_results()
         integer :: unit_num, ios
-        
+
         open(newunit=unit_num, file="fortfem_benchmark_results.dat", &
-             status="replace", action="write", iostat=ios)
-        
+            status="replace", action="write", iostat=ios)
+
         if (ios /= 0) then
             write(*,*) "Warning: Could not save benchmark results"
             return
         end if
-        
+
         write(unit_num, '(A)') "# mesh_size vertices triangles time_seconds"
-        
+
         do i = 1, n_sizes
             write(unit_num, '(I0,1X,I0,1X,I0,1X,ES15.8)') mesh_sizes(i), &
-                  fortfem_vertices(i), fortfem_triangles(i), fortfem_times(i)
+                fortfem_vertices(i), fortfem_triangles(i), fortfem_times(i)
         end do
-        
+
         close(unit_num)
     end subroutine
 

--- a/example/curl_curl/curl_curl.f90
+++ b/example/curl_curl/curl_curl.f90
@@ -2,7 +2,7 @@ program curl_curl_example
     ! Clean FEniCS-style example solving the curl-curl equation
     ! ∇ × (∇ × E) + E = J in Ω = [0,1]²
     ! E × n = 0 on ∂Ω (tangential boundary condition)
-    ! 
+    !
     ! This demonstrates FEniCS-style syntax for electromagnetic problems
     ! using edge elements (Nédélec) and iterative GMRES solver
 
@@ -27,14 +27,14 @@ program curl_curl_example
     write(*,*) ""
 
     ! Create mesh and vector function space using FEniCS-style API
-    mesh = unit_square_mesh(8)  ! 8x8 grid for efficiency
+    mesh = unit_square_mesh(8) ! 8x8 grid for efficiency
     Vh = vector_function_space(mesh, "Nedelec", 1)
-    
+
     n_vertices = mesh%data%n_vertices
     n_elements = mesh%data%n_triangles
     n_dofs = Vh%ndof
-    h = 1.0_dp / 7.0_dp  ! mesh spacing
-    
+    h = 1.0_dp / 7.0_dp ! mesh spacing
+
     write(*,*) "Mesh statistics:"
     write(*,*) "  Vertices:", n_vertices
     write(*,*) "  Elements:", n_elements
@@ -48,12 +48,12 @@ program curl_curl_example
 
     ! Define source current J = [1, 0] (x-directed current)
     J = vector_function(Vh)
-    J%values(:, 1) = 1.0_dp  ! Jx = 1
-    J%values(:, 2) = 0.0_dp  ! Jy = 0
+    J%values(:, 1) = 1.0_dp ! Jx = 1
+    J%values(:, 2) = 0.0_dp ! Jy = 0
 
     ! Define weak form using mathematical notation
-    a = inner(curl(E), curl(F))*dx + inner(E, F)*dx  ! Bilinear form
-    L = inner(J, F)*dx                                ! Linear form
+    a = inner(curl(E), curl(F))*dx + inner(E, F)*dx ! Bilinear form
+    L = inner(J, F)*dx ! Linear form
 
     write(*,*) "Weak form:"
     write(*,*) "  a(E,F) = ", trim(a%description)
@@ -75,43 +75,43 @@ program curl_curl_example
 
     ! Analyze solution
     max_E = maxval(sqrt(Eh%values(:,1)**2 + Eh%values(:,2)**2))
-    
+
     write(*,*) "Solution statistics:"
     write(*,*) "  Max |E| =", max_E
     write(*,*) "  Max Ex =", maxval(abs(Eh%values(:,1)))
     write(*,*) "  Max Ey =", maxval(abs(Eh%values(:,2)))
     write(*,*) ""
-    
+
     ! Plot the numerical solution
     write(*,*) "Creating numerical solution plot..."
     call plot(Eh, filename="curl_curl_numerical.png", &
-              title="Curl-Curl Numerical Solution", &
-              plot_type="streamplot")
-    
+        title="Curl-Curl Numerical Solution", &
+        plot_type="streamplot")
+
     ! Create and plot analytical reference solution E = [x*y, x²]
     write(*,*) "Creating analytical reference solution plot..."
     Eh_ref = vector_function(Vh)
-    
+
     ! Simple approach: set analytical values at mesh centers
     ! For proper implementation, this would need edge element interpolation
     do i = 1, Vh%ndof
         ! Use simple coordinate mapping for demonstration
         if (i <= Vh%ndof/2) then
-            x_coord = 0.3_dp  ! Approximate coordinates
+            x_coord = 0.3_dp ! Approximate coordinates
             y_coord = 0.3_dp
         else
             x_coord = 0.7_dp
-            y_coord = 0.7_dp  
+            y_coord = 0.7_dp
         end if
-        Eh_ref%values(i, 1) = x_coord * y_coord  ! Ex = x*y
-        Eh_ref%values(i, 2) = x_coord * x_coord  ! Ey = x²
+        Eh_ref%values(i, 1) = x_coord * y_coord ! Ex = x*y
+        Eh_ref%values(i, 2) = x_coord * x_coord ! Ey = x²
     end do
-    
+
     call plot(Eh_ref, filename="curl_curl_analytical.png", &
-              title="Curl-Curl Analytical Solution: E=[xy, x²]", &
-              plot_type="streamplot")
+        title="Curl-Curl Analytical Solution: E=[xy, x²]", &
+        plot_type="streamplot")
     write(*,*) ""
-    
+
     write(*,*) "Example completed successfully!"
     write(*,*) ""
     write(*,*) "This example demonstrates:"

--- a/example/fortfem_mesh_benchmark/fortfem_mesh_benchmark.f90
+++ b/example/fortfem_mesh_benchmark/fortfem_mesh_benchmark.f90
@@ -8,45 +8,45 @@ program fortfem_mesh_benchmark
     integer :: mesh_sizes(n_sizes) = [5, 10, 15, 20, 25, 30]
     real(dp) :: fortfem_times(n_sizes)
     integer :: fortfem_vertices(n_sizes), fortfem_triangles(n_sizes)
-    
+
     type(mesh_t) :: mesh
     real(dp) :: start_time, end_time
     integer :: i, n
-    
+
     write(*,*) "=== FortFEM Mesh Generation Benchmark ==="
     write(*,*) ""
-    
+
     ! Run benchmark for each mesh size
     do i = 1, n_sizes
         n = mesh_sizes(i)
-        
+
         write(*,'(A,I0,A,I0,A)') "Testing ", n, "x", n, " mesh:"
-        
+
         ! Time FortFEM mesh generation
         call cpu_time(start_time)
         mesh = unit_square_mesh(n)
         call cpu_time(end_time)
-        
+
         fortfem_times(i) = end_time - start_time
         fortfem_vertices(i) = mesh%data%n_vertices
         fortfem_triangles(i) = mesh%data%n_triangles
-        
+
         write(*,'(A,I0,A,I0,A,ES10.3,A)') "  FortFEM: ", fortfem_vertices(i), &
-               " vertices, ", fortfem_triangles(i), " triangles, ", fortfem_times(i), "s"
+            " vertices, ", fortfem_triangles(i), " triangles, ", fortfem_times(i), "s"
     end do
-    
+
     write(*,*) ""
     write(*,*) "=== Benchmark Results ==="
     write(*,*) "Size	FortFEM_vertices	FortFEM_triangles	FortFEM_time(s)"
-    
+
     do i = 1, n_sizes
         write(*,'(I0,A,I0,A,I0,A,ES10.3)') mesh_sizes(i), "	", fortfem_vertices(i), &
-               "		", fortfem_triangles(i), "		", fortfem_times(i)
+            "		", fortfem_triangles(i), "		", fortfem_times(i)
     end do
-    
+
     ! Save results for comparison
     call save_benchmark_results()
-    
+
     write(*,*) ""
     write(*,*) "FortFEM benchmark completed."
     write(*,*) "Results saved to fortfem_benchmark_results.dat"
@@ -54,27 +54,27 @@ program fortfem_mesh_benchmark
     write(*,*) "To compare with FreeFEM:"
     write(*,*) "1. Run: FreeFem++ benchmark/mesh_comparison.edp"
     write(*,*) "2. Compare fortfem_benchmark_results.dat with freefem_benchmark_results.dat"
-    
+
 contains
 
     subroutine save_benchmark_results()
         integer :: unit_num, ios
-        
+
         open(newunit=unit_num, file="fortfem_benchmark_results.dat", &
-             status="replace", action="write", iostat=ios)
-        
+            status="replace", action="write", iostat=ios)
+
         if (ios /= 0) then
             write(*,*) "Warning: Could not save benchmark results"
             return
         end if
-        
+
         write(unit_num, '(A)') "# mesh_size vertices triangles time_seconds"
-        
+
         do i = 1, n_sizes
             write(unit_num, '(I0,1X,I0,1X,I0,1X,ES15.8)') mesh_sizes(i), &
-                  fortfem_vertices(i), fortfem_triangles(i), fortfem_times(i)
+                fortfem_vertices(i), fortfem_triangles(i), fortfem_times(i)
         end do
-        
+
         close(unit_num)
     end subroutine
 

--- a/example/minimal_mesh_example/minimal_mesh_example.f90
+++ b/example/minimal_mesh_example/minimal_mesh_example.f90
@@ -6,51 +6,51 @@ program minimal_mesh_example
 
     type(mesh_t) :: mesh
     type(boundary_t) :: boundary
-    
+
     write(*,*) "=== FortFEM Minimal Mesh Example ==="
     write(*,*) ""
-    
+
     ! Example 1: Simple unit square mesh
     write(*,*) "1. Unit Square Mesh (5x5 grid)"
     mesh = unit_square_mesh(5)
-    
+
     write(*,'(A,I0)') "   Vertices: ", mesh%data%n_vertices
     write(*,'(A,I0)') "   Triangles: ", mesh%data%n_triangles
     write(*,*) "   ✓ Generated successfully"
     write(*,*) ""
-    
-    ! Example 2: Rectangle mesh  
+
+    ! Example 2: Rectangle mesh
     write(*,*) "2. Rectangle Mesh (3x4 grid on [0,2]×[0,1])"
     mesh = rectangle_mesh(3, 4, [0.0_dp, 2.0_dp, 0.0_dp, 1.0_dp])
-    
+
     write(*,'(A,I0)') "   Vertices: ", mesh%data%n_vertices
     write(*,'(A,I0)') "   Triangles: ", mesh%data%n_triangles
     write(*,*) "   ✓ Generated successfully"
     write(*,*) ""
-    
+
     ! Example 3: Circle boundary
     write(*,*) "3. Circle Boundary (8 points, radius=0.5)"
     boundary = circle_boundary([0.0_dp, 0.0_dp], 0.5_dp, 8)
-    
+
     write(*,'(A,I0)') "   Boundary points: ", boundary%n_points
     write(*,'(A,L1)') "   Is closed: ", boundary%is_closed
     write(*,*) "   ✓ Boundary created successfully"
     write(*,*) ""
-    
+
     ! Example 4: Unit disk mesh (using simple method to avoid validation issues)
     write(*,*) "4. Unit Disk Mesh (resolution=0.3)"
     write(*,*) "   Note: Using rectangular approximation to avoid edge validation issues"
-    mesh = unit_square_mesh(6)  ! Simple approximation for minimal example
-    
-    write(*,'(A,I0)') "   Vertices: ", mesh%data%n_vertices  
+    mesh = unit_square_mesh(6) ! Simple approximation for minimal example
+
+    write(*,'(A,I0)') "   Vertices: ", mesh%data%n_vertices
     write(*,'(A,I0)') "   Triangles: ", mesh%data%n_triangles
     write(*,*) "   ✓ Generated successfully"
     write(*,*) ""
-    
+
     ! Summary
     write(*,*) "=== Summary ==="
     write(*,*) "✓ Unit square mesh generation works"
-    write(*,*) "✓ Rectangle mesh generation works"  
+    write(*,*) "✓ Rectangle mesh generation works"
     write(*,*) "✓ Boundary definitions work"
     write(*,*) "✓ Basic mesh data structures functional"
     write(*,*) ""

--- a/example/plot_mesh/plot_mesh.f90
+++ b/example/plot_mesh/plot_mesh.f90
@@ -1,40 +1,40 @@
 program plot_mesh_example
     ! Example demonstrating mesh plotting functionality in FortFEM
-    
+
     use fortfem_api
     implicit none
-    
+
     type(mesh_t) :: mesh
     integer :: n_refinements
-    
+
     ! Create unit square mesh with different refinement levels
     n_refinements = 5
     mesh = unit_square_mesh(n_refinements)
-    
+
     ! Plot basic mesh
     call plot(mesh, filename="mesh_basic.png", title="Unit Square Mesh")
-    
+
     ! Create finer mesh
     n_refinements = 10
     mesh = unit_square_mesh(n_refinements)
-    
+
     ! Plot finer mesh
     call plot(mesh, filename="mesh_fine.png", title="Refined Unit Square Mesh")
-    
+
     ! Create coarse mesh for clarity
     n_refinements = 3
     mesh = unit_square_mesh(n_refinements)
-    
+
     ! Plot with custom title
     call plot(mesh, filename="mesh_coarse.png", title="Coarse Mesh (3x3)")
-    
+
     ! Clean up
     call mesh%destroy()
-    
+
     print *, "Mesh plotting examples completed!"
     print *, "Generated files:"
     print *, "  - mesh_basic.png"
     print *, "  - mesh_fine.png"
     print *, "  - mesh_coarse.png"
-    
+
 end program plot_mesh_example

--- a/example/plotting/plotting.f90
+++ b/example/plotting/plotting.f90
@@ -1,7 +1,7 @@
 program plotting_demo
     ! Demonstration of FortFEM plotting capabilities
     ! Shows how to easily visualize FEM solutions with a single plot() command
-    
+
     use fortfem_kinds
     use fortfem_api
     implicit none
@@ -14,24 +14,24 @@ program plotting_demo
     type(function_t) :: f
     type(dirichlet_bc_t) :: bc
     type(form_expr_t) :: a, L
-    
+
     write(*,*) "=== FortFEM Plotting Demonstration ==="
     write(*,*) ""
-    
+
     ! Create mesh and function space
-    mesh = unit_square_mesh(15)  ! Fine mesh for better plots
+    mesh = unit_square_mesh(15) ! Fine mesh for better plots
     Vh = function_space(mesh, "Lagrange", 1)
-    
+
     u = trial_function(Vh)
     v = test_function(Vh)
     bc = dirichlet_bc(Vh, 0.0_dp)
-    
+
     ! Define weak form for Poisson equation
     a = inner(grad(u), grad(v))*dx
-    
+
     write(*,*) "Creating multiple solutions with different source terms..."
     write(*,*) ""
-    
+
     ! Solution 1: Constant source f = 1
     write(*,*) "1. Constant source f = 1"
     f = constant(1.0_dp)
@@ -39,9 +39,9 @@ program plotting_demo
     uh1 = function(Vh)
     call solve(a == L, uh1, bc)
     call plot(uh1, filename="solution_constant.png", &
-              title="Constant Source: f = 1", &
-              colormap="viridis")
-    
+        title="Constant Source: f = 1", &
+        colormap="viridis")
+
     ! Solution 2: Point source (approximated by high value in center)
     write(*,*) "2. Point source (approximated)"
     f = constant(10.0_dp)
@@ -49,15 +49,15 @@ program plotting_demo
     uh2 = function(Vh)
     call solve(a == L, uh2, bc)
     call plot(uh2, filename="solution_point.png", &
-              title="Point Source: f = 10", &
-              colormap="plasma")
-    
+        title="Point Source: f = 10", &
+        colormap="plasma")
+
     ! Solution 3: Different colormap demonstration
     write(*,*) "3. Same solution with different colormap"
     call plot(uh1, filename="solution_coolwarm.png", &
-              title="Constant Source with Cool-Warm Colormap", &
-              colormap="coolwarm")
-    
+        title="Constant Source with Cool-Warm Colormap", &
+        colormap="coolwarm")
+
     write(*,*) ""
     write(*,*) "Generated plots:"
     write(*,*) "- solution_constant.png   (viridis colormap)"

--- a/example/simple_poisson/simple_poisson.f90
+++ b/example/simple_poisson/simple_poisson.f90
@@ -13,7 +13,7 @@ program simple_poisson
 
     mesh = unit_square_mesh(20)
     Vh = function_space(mesh, "Lagrange", 1)
-    
+
     u = trial_function(Vh)
     v = test_function(Vh)
     f = constant(1.0_dp)
@@ -25,14 +25,14 @@ program simple_poisson
     uh = function(Vh)
 
     call solve(a == L, uh, bc)
-    
+
     ! Plot mesh
     call plot(mesh, filename="poisson_mesh.png", title="Poisson Mesh (20x20)")
-    
+
     ! Plot solution
     call plot(uh, filename="poisson_solution.png", &
-              title="Poisson Solution: -Δu = 1", &
-              colormap="viridis")
+        title="Poisson Solution: -Δu = 1", &
+        colormap="viridis")
 
     write(*,*) "Simple Poisson example completed!"
     write(*,*) "Generated files:"

--- a/example/solver_benchmark/solver_benchmark.f90
+++ b/example/solver_benchmark/solver_benchmark.f90
@@ -1,10 +1,10 @@
 program solver_benchmark
     use fortfem_kinds, only: dp
     use fortfem_api, only: mesh_t, function_space_t, dirichlet_bc_t, &
-                           unit_square_mesh, function_space, dirichlet_bc, &
-                           assemble_laplacian_system
+        unit_square_mesh, function_space, dirichlet_bc, &
+        assemble_laplacian_system
     use fortfem_advanced_solvers, only: solver_options_t, solver_stats_t, &
-                                        solver_options, solve
+        solver_options, solve
     implicit none
 
     call run_solver_benchmark()
@@ -32,13 +32,13 @@ contains
 
         do i = 1, n_cases
             call build_laplacian_system(mesh_sizes(i), mesh, Vh, bc, K, F, &
-                                        dofs(i))
+                dofs(i))
             call benchmark_solvers(K, F, direct_times(i), pcg_times(i), &
-                                   pcg_iters(i), direct_residuals(i), &
-                                   pcg_residuals(i))
+                pcg_iters(i), direct_residuals(i), &
+                pcg_residuals(i))
 
             speedup = max(direct_times(i), 1.0e-12_dp)/ &
-                      max(pcg_times(i), 1.0e-12_dp)
+                max(pcg_times(i), 1.0e-12_dp)
 
             write (*, '(A,I4,A,I8,A,ES12.4,A,ES12.4,A,I6)') &
                 " case ", i, ": DOFs=", dofs(i), "  t_direct=", &
@@ -48,8 +48,8 @@ contains
         end do
 
         call write_benchmark_report(mesh_sizes, dofs, direct_times, &
-                                    pcg_times, pcg_iters, direct_residuals, &
-                                    pcg_residuals)
+            pcg_times, pcg_iters, direct_residuals, &
+            pcg_residuals)
     end subroutine run_solver_benchmark
 
     subroutine build_laplacian_system(n_mesh, mesh, Vh, bc, K, F, ndof)
@@ -69,7 +69,7 @@ contains
     end subroutine build_laplacian_system
 
     subroutine benchmark_solvers(K, F, direct_time, pcg_time, pcg_iters, &
-                                 direct_residual, pcg_residual)
+            direct_residual, pcg_residual)
         real(dp), intent(in) :: K(:, :), F(:)
         real(dp), intent(out) :: direct_time, pcg_time
         integer, intent(out) :: pcg_iters
@@ -90,14 +90,14 @@ contains
         target_tolerance = 1.0e-6_dp
 
         opts_direct = solver_options(method="lapack_lu", &
-                                     tolerance=1.0e-10_dp, &
-                                     max_iterations=ndof)
+            tolerance=1.0e-10_dp, &
+            max_iterations=ndof)
         call solve(K, F, x_direct, opts_direct, stats_direct)
 
         opts_pcg = solver_options(method="pcg", preconditioner="ilu", &
-                                  tolerance=target_tolerance, &
-                                  tolerance_type="absolute", &
-                                  max_iterations=5*ndof)
+            tolerance=target_tolerance, &
+            tolerance_type="absolute", &
+            max_iterations=5*ndof)
         call solve(K, F, x_pcg, opts_pcg, stats_pcg)
 
         direct_residual = norm2(K, F, x_direct)
@@ -119,23 +119,23 @@ contains
     end function norm2
 
     subroutine write_benchmark_report(mesh_sizes, dofs, direct_times, &
-                                      pcg_times, pcg_iters, &
-                                      direct_residuals, pcg_residuals)
+            pcg_times, pcg_iters, &
+            direct_residuals, pcg_residuals)
         integer, intent(in) :: mesh_sizes(:), dofs(:), pcg_iters(:)
         real(dp), intent(in) :: direct_times(:), pcg_times(:)
         real(dp), intent(in) :: direct_residuals(:), pcg_residuals(:)
 
         integer :: unit_num, ios, i, n_cases
         character(len=*), parameter :: filename = &
-                                       "artifacts/solver_benchmarks/"// &
-                                       "poisson_solver_benchmark.txt"
+            "artifacts/solver_benchmarks/"// &
+            "poisson_solver_benchmark.txt"
 
         n_cases = size(mesh_sizes)
 
         call ensure_benchmark_directory()
 
         open (newunit=unit_num, file=filename, status="replace", &
-              action="write", iostat=ios)
+            action="write", iostat=ios)
 
         if (ios /= 0) then
             write (*, *) "Warning: Could not write solver benchmark file"
@@ -148,7 +148,7 @@ contains
 
         do i = 1, n_cases
             write (unit_num, &
-                   '(I6,1X,I8,1X,ES15.8,1X,ES15.8,1X,I6,1X,ES15.8,1X,ES15.8)') &
+                '(I6,1X,I8,1X,ES15.8,1X,ES15.8,1X,I6,1X,ES15.8,1X,ES15.8)') &
                 mesh_sizes(i), dofs(i), direct_times(i), pcg_times(i), &
                 pcg_iters(i), direct_residuals(i), pcg_residuals(i)
         end do

--- a/src/basis/basis_edge_2d.f90
+++ b/src/basis/basis_edge_2d.f90
@@ -3,24 +3,24 @@ module fortfem_basis_edge_2d
     use fortfem_mesh_2d
     implicit none
     private
-    
+
     public :: edge_basis_2d_t
     public :: evaluate_edge_basis_2d
     public :: evaluate_edge_basis_curl_2d
     public :: evaluate_edge_basis_div_2d
     public :: evaluate_edge_basis_2d_piola
-    
+
     ! Edge element basis functions (Nédélec elements)
     type :: edge_basis_2d_t
         integer :: n_edges = 0
-        real(dp), allocatable :: edge_vectors(:,:)  ! Direction vectors
-        real(dp), allocatable :: edge_lengths(:)    ! Edge lengths
+        real(dp), allocatable :: edge_vectors(:,:) ! Direction vectors
+        real(dp), allocatable :: edge_lengths(:) ! Edge lengths
     contains
         procedure :: init => edge_basis_init
         procedure :: destroy => edge_basis_destroy
         procedure :: n_dofs => edge_basis_n_dofs
     end type edge_basis_2d_t
-    
+
 contains
 
     subroutine edge_basis_init(this, mesh)
@@ -28,129 +28,129 @@ contains
         type(mesh_2d_t), intent(in) :: mesh
         integer :: i, j, k, edge_count
         real(dp) :: dx, dy
-        
+
         ! Count edges (3 per triangle)
         this%n_edges = 3 * mesh%n_triangles
-        
+
         allocate(this%edge_vectors(2, this%n_edges))
         allocate(this%edge_lengths(this%n_edges))
-        
+
         edge_count = 0
-        
+
         ! For each triangle, compute edge vectors
         do i = 1, mesh%n_triangles
             do j = 1, 3
                 edge_count = edge_count + 1
-                
+
                 ! Next vertex (cyclic)
                 k = mod(j, 3) + 1
-                
+
                 ! Edge vector
                 dx = mesh%vertices(1, mesh%triangles(k, i)) - &
-                     mesh%vertices(1, mesh%triangles(j, i))
+                    mesh%vertices(1, mesh%triangles(j, i))
                 dy = mesh%vertices(2, mesh%triangles(k, i)) - &
-                     mesh%vertices(2, mesh%triangles(j, i))
-                
+                    mesh%vertices(2, mesh%triangles(j, i))
+
                 this%edge_vectors(1, edge_count) = dx
                 this%edge_vectors(2, edge_count) = dy
                 this%edge_lengths(edge_count) = sqrt(dx**2 + dy**2)
             end do
         end do
     end subroutine edge_basis_init
-    
+
     subroutine edge_basis_destroy(this)
         class(edge_basis_2d_t), intent(inout) :: this
         if (allocated(this%edge_vectors)) deallocate(this%edge_vectors)
         if (allocated(this%edge_lengths)) deallocate(this%edge_lengths)
         this%n_edges = 0
     end subroutine edge_basis_destroy
-    
+
     function edge_basis_n_dofs(this) result(n)
         class(edge_basis_2d_t), intent(in) :: this
         integer :: n
         n = this%n_edges
     end function edge_basis_n_dofs
-    
+
     ! Evaluate edge basis functions at reference coordinates
     subroutine evaluate_edge_basis_2d(xi, eta, triangle_area, values)
         real(dp), intent(in) :: xi, eta, triangle_area
-        real(dp), intent(out) :: values(2, 3)  ! 2D vectors, 3 edges
-        
+        real(dp), intent(out) :: values(2, 3) ! 2D vectors, 3 edges
+
         ! RT0Ortho/Nédélec elements on reference triangle (0,0)-(1,0)-(0,1)
         ! Based on FreeFEM's RT0Ortho implementation which is RT0 rotated by 90°
         ! RT0 basis functions rotated: (x,y) → (-y,x)
         ! This gives H(curl) conforming edge elements
-        
+
         real(dp) :: rt0_values(2, 3)
-        
+
         ! First compute RT0 basis functions
         ! RT0 edge 0: φ₀ = (1-eta, 0)/(2*area)
-        ! RT0 edge 1: φ₁ = (xi, eta-1)/(2*area)  
+        ! RT0 edge 1: φ₁ = (xi, eta-1)/(2*area)
         ! RT0 edge 2: φ₂ = (-xi, 1-eta)/(2*area)
-        
+
         ! Normalize by triangle area for proper scaling
         real(dp) :: scale_factor
         scale_factor = 1.0_dp / (2.0_dp * triangle_area)
-        
+
         rt0_values(1, 1) = (1.0_dp - eta) * scale_factor
         rt0_values(2, 1) = 0.0_dp
-        
+
         rt0_values(1, 2) = xi * scale_factor
         rt0_values(2, 2) = (eta - 1.0_dp) * scale_factor
-        
+
         rt0_values(1, 3) = -xi * scale_factor
         rt0_values(2, 3) = (1.0_dp - eta) * scale_factor
-        
+
         ! Apply 90° rotation: (x,y) → (-y,x) to get RT0Ortho
-        values(1, 1) = -rt0_values(2, 1)  ! -0 = 0
-        values(2, 1) = rt0_values(1, 1)   ! (1-eta)/2A
-        
-        values(1, 2) = -rt0_values(2, 2)  ! -(eta-1)/2A = (1-eta)/2A
-        values(2, 2) = rt0_values(1, 2)   ! xi/2A
-        
-        values(1, 3) = -rt0_values(2, 3)  ! -(1-eta)/2A = (eta-1)/2A
-        values(2, 3) = rt0_values(1, 3)   ! -xi/2A
+        values(1, 1) = -rt0_values(2, 1) ! -0 = 0
+        values(2, 1) = rt0_values(1, 1) ! (1-eta)/2A
+
+        values(1, 2) = -rt0_values(2, 2) ! -(eta-1)/2A = (1-eta)/2A
+        values(2, 2) = rt0_values(1, 2) ! xi/2A
+
+        values(1, 3) = -rt0_values(2, 3) ! -(1-eta)/2A = (eta-1)/2A
+        values(2, 3) = rt0_values(1, 3) ! -xi/2A
     end subroutine evaluate_edge_basis_2d
-    
+
     ! Evaluate curl of edge basis functions
     subroutine evaluate_edge_basis_curl_2d(xi, eta, triangle_area, curls)
         real(dp), intent(in) :: xi, eta, triangle_area
-        real(dp), intent(out) :: curls(3)  ! Scalar curl in 2D
-        
+        real(dp), intent(out) :: curls(3) ! Scalar curl in 2D
+
         ! For 2D vector field φ = (φˣ, φʸ), curl(φ) = ∂φʸ/∂ξ - ∂φˣ/∂η
         ! Then transform from reference to physical: curl_phys = curl_ref / jacobian_det
         ! where jacobian_det = 2 * triangle_area for linear triangular mapping
-        
+
         real(dp) :: jacobian_det, scale_factor
         jacobian_det = 2.0_dp * triangle_area
         scale_factor = 1.0_dp / (2.0_dp * triangle_area)
-        
+
         ! For RT0Ortho basis functions (RT0 rotated by 90°):
         ! φ₀ = (0, (1-eta)/(2A)): curl = ∂((1-eta)/(2A))/∂ξ - ∂(0)/∂η = 0 - 0 = 0
-        ! φ₁ = ((1-eta)/(2A), xi/(2A)): curl = ∂(xi/(2A))/∂ξ - ∂((1-eta)/(2A))/∂η 
+        ! φ₁ = ((1-eta)/(2A), xi/(2A)): curl = ∂(xi/(2A))/∂ξ - ∂((1-eta)/(2A))/∂η
         !      = 1/(2A) - (-1/(2A)) = 2/(2A) = 1/A
         ! φ₂ = ((eta-1)/(2A), -xi/(2A)): curl = ∂(-xi/(2A))/∂ξ - ∂((eta-1)/(2A))/∂η
         !      = -1/(2A) - 1/(2A) = -2/(2A) = -1/A
-        
+
         ! Transform to physical element (already in physical coordinates)
         curls(1) = 0.0_dp
         curls(2) = 1.0_dp / triangle_area
         curls(3) = -1.0_dp / triangle_area
     end subroutine evaluate_edge_basis_curl_2d
-    
+
     ! Evaluate edge basis functions with Piola transformation
     subroutine evaluate_edge_basis_2d_piola(mesh, triangle_idx, xi, eta, values)
         type(mesh_2d_t), intent(in) :: mesh
         integer, intent(in) :: triangle_idx
         real(dp), intent(in) :: xi, eta
-        real(dp), intent(out) :: values(2, 3)  ! 2D vectors, 3 edges
-        
-        real(dp) :: ref_values(2, 3)  ! Reference basis values
+        real(dp), intent(out) :: values(2, 3) ! 2D vectors, 3 edges
+
+        real(dp) :: ref_values(2, 3) ! Reference basis values
         real(dp) :: jacobian(2, 2), inv_jacobian(2, 2), det_jacobian
         real(dp) :: triangle_area
         integer :: i, j, k
         real(dp) :: x1, y1, x2, y2, x3, y3
-        
+
         ! Get triangle vertices
         x1 = mesh%vertices(1, mesh%triangles(1, triangle_idx))
         y1 = mesh%vertices(2, mesh%triangles(1, triangle_idx))
@@ -158,31 +158,31 @@ contains
         y2 = mesh%vertices(2, mesh%triangles(2, triangle_idx))
         x3 = mesh%vertices(1, mesh%triangles(3, triangle_idx))
         y3 = mesh%vertices(2, mesh%triangles(3, triangle_idx))
-        
+
         ! Compute Jacobian matrix: F = [∂x/∂ξ, ∂x/∂η; ∂y/∂ξ, ∂y/∂η]
-        jacobian(1, 1) = x2 - x1  ! ∂x/∂ξ
-        jacobian(1, 2) = x3 - x1  ! ∂x/∂η
-        jacobian(2, 1) = y2 - y1  ! ∂y/∂ξ
-        jacobian(2, 2) = y3 - y1  ! ∂y/∂η
-        
+        jacobian(1, 1) = x2 - x1 ! ∂x/∂ξ
+        jacobian(1, 2) = x3 - x1 ! ∂x/∂η
+        jacobian(2, 1) = y2 - y1 ! ∂y/∂ξ
+        jacobian(2, 2) = y3 - y1 ! ∂y/∂η
+
         det_jacobian = jacobian(1, 1) * jacobian(2, 2) - jacobian(1, 2) * jacobian(2, 1)
         triangle_area = 0.5_dp * abs(det_jacobian)
-        
+
         ! Evaluate reference basis functions
         call evaluate_edge_basis_2d(xi, eta, triangle_area, ref_values)
-        
+
         ! Apply Piola transformation: φ_phys = (1/J) * F * φ_ref
         do i = 1, 3
             values(1, i) = (jacobian(1, 1) * ref_values(1, i) + jacobian(1, 2) * ref_values(2, i)) / det_jacobian
             values(2, i) = (jacobian(2, 1) * ref_values(1, i) + jacobian(2, 2) * ref_values(2, i)) / det_jacobian
         end do
     end subroutine evaluate_edge_basis_2d_piola
-    
+
     ! Evaluate divergence of edge basis functions
     subroutine evaluate_edge_basis_div_2d(xi, eta, triangle_area, divs)
         real(dp), intent(in) :: xi, eta, triangle_area
-        real(dp), intent(out) :: divs(3)  ! Divergence values
-        
+        real(dp), intent(out) :: divs(3) ! Divergence values
+
         ! Divergence of Nédélec elements (should be zero for H(curl))
         divs(1) = 0.0_dp
         divs(2) = 0.0_dp

--- a/src/basis/basis_p1_2d.f90
+++ b/src/basis/basis_p1_2d.f90
@@ -2,23 +2,23 @@ module basis_p1_2d_module
     use fortfem_kinds
     implicit none
     private
-    
+
     public :: basis_p1_2d_t
-    
+
     type :: basis_p1_2d_t
         ! Reference triangle nodes
         real(dp) :: nodes(2,3) = reshape([ &
-            0.0_dp, 0.0_dp, &  ! Node 1
-            1.0_dp, 0.0_dp, &  ! Node 2
-            0.0_dp, 1.0_dp  &  ! Node 3
-        ], [2, 3])
+            0.0_dp, 0.0_dp, & ! Node 1
+            1.0_dp, 0.0_dp, & ! Node 2
+            0.0_dp, 1.0_dp  & ! Node 3
+            ], [2, 3])
     contains
         procedure :: eval
         procedure :: grad
         procedure :: transform_to_physical
         procedure :: compute_jacobian
     end type basis_p1_2d_t
-    
+
 contains
 
     pure function eval(this, i, xi, eta) result(val)
@@ -26,7 +26,7 @@ contains
         integer, intent(in) :: i
         real(dp), intent(in) :: xi, eta
         real(dp) :: val
-        
+
         select case (i)
         case (1)
             ! phi_1 = 1 - xi - eta
@@ -40,15 +40,15 @@ contains
         case default
             val = 0.0_dp
         end select
-        
+
     end function eval
-    
+
     pure function grad(this, i, xi, eta) result(gradient)
         class(basis_p1_2d_t), intent(in) :: this
         integer, intent(in) :: i
         real(dp), intent(in) :: xi, eta
         real(dp) :: gradient(2)
-        
+
         ! P1 gradients are constant
         select case (i)
         case (1)
@@ -63,27 +63,27 @@ contains
         case default
             gradient = [0.0_dp, 0.0_dp]
         end select
-        
+
     end function grad
-    
+
     pure subroutine transform_to_physical(this, xi, eta, vertices, x, y)
         class(basis_p1_2d_t), intent(in) :: this
         real(dp), intent(in) :: xi, eta
         real(dp), intent(in) :: vertices(2,3)
         real(dp), intent(out) :: x, y
         integer :: i
-        
+
         x = 0.0_dp
         y = 0.0_dp
-        
+
         ! Linear transformation using basis functions
         do i = 1, 3
             x = x + vertices(1,i) * this%eval(i, xi, eta)
             y = y + vertices(2,i) * this%eval(i, xi, eta)
         end do
-        
+
     end subroutine transform_to_physical
-    
+
     pure subroutine compute_jacobian(this, vertices, jac, det_j)
         class(basis_p1_2d_t), intent(in) :: this
         real(dp), intent(in) :: vertices(2,3)
@@ -91,23 +91,23 @@ contains
         real(dp), intent(out) :: det_j
         integer :: i
         real(dp) :: grad_ref(2)
-        
+
         ! Initialize Jacobian
         jac = 0.0_dp
-        
+
         ! Jacobian of transformation
         ! J = sum_i vertices_i * grad(phi_i)^T
         do i = 1, 3
-            grad_ref = this%grad(i, 0.0_dp, 0.0_dp)  ! Constant for P1
+            grad_ref = this%grad(i, 0.0_dp, 0.0_dp) ! Constant for P1
             jac(1,1) = jac(1,1) + vertices(1,i) * grad_ref(1)
             jac(1,2) = jac(1,2) + vertices(1,i) * grad_ref(2)
             jac(2,1) = jac(2,1) + vertices(2,i) * grad_ref(1)
             jac(2,2) = jac(2,2) + vertices(2,i) * grad_ref(2)
         end do
-        
+
         ! Determinant
         det_j = jac(1,1) * jac(2,2) - jac(1,2) * jac(2,1)
-        
+
     end subroutine compute_jacobian
 
 end module basis_p1_2d_module

--- a/src/basis/basis_p2_2d.f90
+++ b/src/basis/basis_p2_2d.f90
@@ -2,21 +2,21 @@ module basis_p2_2d_module
     use fortfem_kinds
     implicit none
     private
-    
+
     public :: basis_p2_2d_t
-    
+
     type :: basis_p2_2d_t
         ! Reference triangle nodes for P2 elements
         ! Vertices: (0,0), (1,0), (0,1)
         ! Edge midpoints: (0.5,0), (0.5,0.5), (0,0.5)
         real(dp) :: nodes(2,6) = reshape([ &
-            0.0_dp, 0.0_dp, &  ! Node 1 (vertex)
-            1.0_dp, 0.0_dp, &  ! Node 2 (vertex)
-            0.0_dp, 1.0_dp, &  ! Node 3 (vertex)
-            0.5_dp, 0.0_dp, &  ! Node 4 (edge 1-2 midpoint)
-            0.5_dp, 0.5_dp, &  ! Node 5 (edge 2-3 midpoint)
-            0.0_dp, 0.5_dp  &  ! Node 6 (edge 3-1 midpoint)
-        ], [2, 6])
+            0.0_dp, 0.0_dp, & ! Node 1 (vertex)
+            1.0_dp, 0.0_dp, & ! Node 2 (vertex)
+            0.0_dp, 1.0_dp, & ! Node 3 (vertex)
+            0.5_dp, 0.0_dp, & ! Node 4 (edge 1-2 midpoint)
+            0.5_dp, 0.5_dp, & ! Node 5 (edge 2-3 midpoint)
+            0.0_dp, 0.5_dp  & ! Node 6 (edge 3-1 midpoint)
+            ], [2, 6])
     contains
         procedure :: eval
         procedure :: grad
@@ -25,7 +25,7 @@ module basis_p2_2d_module
         procedure :: compute_jacobian
         procedure :: get_num_dofs
     end type basis_p2_2d_t
-    
+
 contains
 
     pure function get_num_dofs(this) result(n)
@@ -40,12 +40,12 @@ contains
         real(dp), intent(in) :: xi, eta
         real(dp) :: val
         real(dp) :: lambda1, lambda2, lambda3
-        
+
         ! Barycentric coordinates
         lambda1 = 1.0_dp - xi - eta
         lambda2 = xi
         lambda3 = eta
-        
+
         select case (i)
         case (1)
             ! Vertex 1: phi_1 = lambda1 * (2*lambda1 - 1)
@@ -68,9 +68,9 @@ contains
         case default
             val = 0.0_dp
         end select
-        
+
     end function eval
-    
+
     pure function grad(this, i, xi, eta) result(gradient)
         class(basis_p2_2d_t), intent(in) :: this
         integer, intent(in) :: i
@@ -80,12 +80,12 @@ contains
         real(dp) :: d_lambda1_dxi, d_lambda1_deta
         real(dp) :: d_lambda2_dxi, d_lambda2_deta
         real(dp) :: d_lambda3_dxi, d_lambda3_deta
-        
+
         ! Barycentric coordinates
         lambda1 = 1.0_dp - xi - eta
         lambda2 = xi
         lambda3 = eta
-        
+
         ! Gradients of barycentric coordinates
         d_lambda1_dxi = -1.0_dp
         d_lambda1_deta = -1.0_dp
@@ -93,7 +93,7 @@ contains
         d_lambda2_deta = 0.0_dp
         d_lambda3_dxi = 0.0_dp
         d_lambda3_deta = 1.0_dp
-        
+
         select case (i)
         case (1)
             ! grad(phi_1) = grad(lambda1 * (2*lambda1 - 1))
@@ -122,9 +122,9 @@ contains
         case default
             gradient = [0.0_dp, 0.0_dp]
         end select
-        
+
     end function grad
-    
+
     pure function hessian(this, i, xi, eta) result(hess)
         class(basis_p2_2d_t), intent(in) :: this
         integer, intent(in) :: i
@@ -133,7 +133,7 @@ contains
         real(dp) :: d2_lambda1_dxi2, d2_lambda1_dxideta, d2_lambda1_deta2
         real(dp) :: d2_lambda2_dxi2, d2_lambda2_dxideta, d2_lambda2_deta2
         real(dp) :: d2_lambda3_dxi2, d2_lambda3_dxideta, d2_lambda3_deta2
-        
+
         ! Second derivatives of barycentric coordinates (all zero for linear functions)
         d2_lambda1_dxi2 = 0.0_dp
         d2_lambda1_dxideta = 0.0_dp
@@ -144,50 +144,50 @@ contains
         d2_lambda3_dxi2 = 0.0_dp
         d2_lambda3_dxideta = 0.0_dp
         d2_lambda3_deta2 = 0.0_dp
-        
+
         select case (i)
         case (1)
             ! hess(phi_1) = hess(lambda1 * (2*lambda1 - 1))
-            hess(1,1) = 4.0_dp * (-1.0_dp) * (-1.0_dp)  ! d2/dxi2
-            hess(1,2) = 4.0_dp * (-1.0_dp) * (-1.0_dp)  ! d2/dxideta
-            hess(2,1) = hess(1,2)                        ! d2/detadxi
-            hess(2,2) = 4.0_dp * (-1.0_dp) * (-1.0_dp)  ! d2/deta2
+            hess(1,1) = 4.0_dp * (-1.0_dp) * (-1.0_dp) ! d2/dxi2
+            hess(1,2) = 4.0_dp * (-1.0_dp) * (-1.0_dp) ! d2/dxideta
+            hess(2,1) = hess(1,2) ! d2/detadxi
+            hess(2,2) = 4.0_dp * (-1.0_dp) * (-1.0_dp) ! d2/deta2
         case (2)
             ! hess(phi_2) = hess(lambda2 * (2*lambda2 - 1))
-            hess(1,1) = 4.0_dp * 1.0_dp * 1.0_dp       ! d2/dxi2
-            hess(1,2) = 0.0_dp                          ! d2/dxideta
-            hess(2,1) = 0.0_dp                          ! d2/detadxi
-            hess(2,2) = 0.0_dp                          ! d2/deta2
+            hess(1,1) = 4.0_dp * 1.0_dp * 1.0_dp ! d2/dxi2
+            hess(1,2) = 0.0_dp ! d2/dxideta
+            hess(2,1) = 0.0_dp ! d2/detadxi
+            hess(2,2) = 0.0_dp ! d2/deta2
         case (3)
             ! hess(phi_3) = hess(lambda3 * (2*lambda3 - 1))
-            hess(1,1) = 0.0_dp                          ! d2/dxi2
-            hess(1,2) = 0.0_dp                          ! d2/dxideta
-            hess(2,1) = 0.0_dp                          ! d2/detadxi
-            hess(2,2) = 4.0_dp * 1.0_dp * 1.0_dp       ! d2/deta2
+            hess(1,1) = 0.0_dp ! d2/dxi2
+            hess(1,2) = 0.0_dp ! d2/dxideta
+            hess(2,1) = 0.0_dp ! d2/detadxi
+            hess(2,2) = 4.0_dp * 1.0_dp * 1.0_dp ! d2/deta2
         case (4)
             ! hess(phi_4) = hess(4 * lambda1 * lambda2)
-            hess(1,1) = 0.0_dp                          ! d2/dxi2
-            hess(1,2) = 4.0_dp * (-1.0_dp) * 1.0_dp    ! d2/dxideta
-            hess(2,1) = hess(1,2)                       ! d2/detadxi
-            hess(2,2) = 0.0_dp                          ! d2/deta2
+            hess(1,1) = 0.0_dp ! d2/dxi2
+            hess(1,2) = 4.0_dp * (-1.0_dp) * 1.0_dp ! d2/dxideta
+            hess(2,1) = hess(1,2) ! d2/detadxi
+            hess(2,2) = 0.0_dp ! d2/deta2
         case (5)
             ! hess(phi_5) = hess(4 * lambda2 * lambda3)
-            hess(1,1) = 0.0_dp                          ! d2/dxi2
-            hess(1,2) = 4.0_dp * 1.0_dp * 1.0_dp       ! d2/dxideta
-            hess(2,1) = hess(1,2)                       ! d2/detadxi
-            hess(2,2) = 0.0_dp                          ! d2/deta2
+            hess(1,1) = 0.0_dp ! d2/dxi2
+            hess(1,2) = 4.0_dp * 1.0_dp * 1.0_dp ! d2/dxideta
+            hess(2,1) = hess(1,2) ! d2/detadxi
+            hess(2,2) = 0.0_dp ! d2/deta2
         case (6)
             ! hess(phi_6) = hess(4 * lambda3 * lambda1)
-            hess(1,1) = 0.0_dp                          ! d2/dxi2
-            hess(1,2) = 4.0_dp * 1.0_dp * (-1.0_dp)    ! d2/dxideta
-            hess(2,1) = hess(1,2)                       ! d2/detadxi
-            hess(2,2) = 0.0_dp                          ! d2/deta2
+            hess(1,1) = 0.0_dp ! d2/dxi2
+            hess(1,2) = 4.0_dp * 1.0_dp * (-1.0_dp) ! d2/dxideta
+            hess(2,1) = hess(1,2) ! d2/detadxi
+            hess(2,2) = 0.0_dp ! d2/deta2
         case default
             hess = 0.0_dp
         end select
-        
+
     end function hessian
-    
+
     pure subroutine transform_to_physical(this, xi, eta, vertices, x, y)
         class(basis_p2_2d_t), intent(in) :: this
         real(dp), intent(in) :: xi, eta
@@ -195,26 +195,26 @@ contains
         real(dp), intent(out) :: x, y
         integer :: i
         real(dp) :: nodes_physical(2,6)
-        
+
         ! Set vertex nodes
         nodes_physical(:,1:3) = vertices(:,1:3)
-        
+
         ! Compute edge midpoints
-        nodes_physical(:,4) = 0.5_dp * (vertices(:,1) + vertices(:,2))  ! Edge 1-2
-        nodes_physical(:,5) = 0.5_dp * (vertices(:,2) + vertices(:,3))  ! Edge 2-3
-        nodes_physical(:,6) = 0.5_dp * (vertices(:,3) + vertices(:,1))  ! Edge 3-1
-        
+        nodes_physical(:,4) = 0.5_dp * (vertices(:,1) + vertices(:,2)) ! Edge 1-2
+        nodes_physical(:,5) = 0.5_dp * (vertices(:,2) + vertices(:,3)) ! Edge 2-3
+        nodes_physical(:,6) = 0.5_dp * (vertices(:,3) + vertices(:,1)) ! Edge 3-1
+
         x = 0.0_dp
         y = 0.0_dp
-        
+
         ! Quadratic transformation using basis functions
         do i = 1, 6
             x = x + nodes_physical(1,i) * this%eval(i, xi, eta)
             y = y + nodes_physical(2,i) * this%eval(i, xi, eta)
         end do
-        
+
     end subroutine transform_to_physical
-    
+
     pure subroutine compute_jacobian(this, vertices, jac, det_j)
         class(basis_p2_2d_t), intent(in) :: this
         real(dp), intent(in) :: vertices(2,3)
@@ -223,18 +223,18 @@ contains
         integer :: i
         real(dp) :: grad_ref(2)
         real(dp) :: nodes_physical(2,6)
-        
+
         ! Set vertex nodes
         nodes_physical(:,1:3) = vertices(:,1:3)
-        
+
         ! Compute edge midpoints
-        nodes_physical(:,4) = 0.5_dp * (vertices(:,1) + vertices(:,2))  ! Edge 1-2
-        nodes_physical(:,5) = 0.5_dp * (vertices(:,2) + vertices(:,3))  ! Edge 2-3
-        nodes_physical(:,6) = 0.5_dp * (vertices(:,3) + vertices(:,1))  ! Edge 3-1
-        
+        nodes_physical(:,4) = 0.5_dp * (vertices(:,1) + vertices(:,2)) ! Edge 1-2
+        nodes_physical(:,5) = 0.5_dp * (vertices(:,2) + vertices(:,3)) ! Edge 2-3
+        nodes_physical(:,6) = 0.5_dp * (vertices(:,3) + vertices(:,1)) ! Edge 3-1
+
         ! Initialize Jacobian
         jac = 0.0_dp
-        
+
         ! Jacobian of transformation at reference element center (1/3, 1/3)
         ! J = sum_i nodes_i * grad(phi_i)^T
         do i = 1, 6
@@ -244,10 +244,10 @@ contains
             jac(2,1) = jac(2,1) + nodes_physical(2,i) * grad_ref(1)
             jac(2,2) = jac(2,2) + nodes_physical(2,i) * grad_ref(2)
         end do
-        
+
         ! Determinant
         det_j = jac(1,1) * jac(2,2) - jac(1,2) * jac(2,1)
-        
+
     end subroutine compute_jacobian
 
 end module basis_p2_2d_module

--- a/src/basis/basis_q1_quad_2d.f90
+++ b/src/basis/basis_q1_quad_2d.f90
@@ -48,10 +48,10 @@ contains
         call q1_shape_derivatives(xi, eta, dN_dxi, dN_deta)
 
         ! Jacobian of mapping x(xi,eta) = sum_i N_i(xi,eta) * x_i
-        jac(1,1) = sum(dN_dxi  * coords(1,:))   ! dx/dxi
-        jac(1,2) = sum(dN_deta * coords(1,:))   ! dx/deta
-        jac(2,1) = sum(dN_dxi  * coords(2,:))   ! dy/dxi
-        jac(2,2) = sum(dN_deta * coords(2,:))   ! dy/deta
+        jac(1,1) = sum(dN_dxi  * coords(1,:)) ! dx/dxi
+        jac(1,2) = sum(dN_deta * coords(1,:)) ! dx/deta
+        jac(2,1) = sum(dN_dxi  * coords(2,:)) ! dy/dxi
+        jac(2,2) = sum(dN_deta * coords(2,:)) ! dy/deta
 
         det_jac = jac(1,1) * jac(2,2) - jac(1,2) * jac(2,1)
 

--- a/src/elements/basis_1d.f90
+++ b/src/elements/basis_1d.f90
@@ -2,26 +2,26 @@ module fortfem_basis_1d
     use fortfem_kinds
     implicit none
     private
-    
+
     public :: p1_basis, p1_basis_derivative, basis_1d_t
-    
+
     type :: basis_1d_t
-        integer :: n_basis = 2  ! P1 elements have 2 basis functions
-        integer :: element_type = 1  ! 1=P1
+        integer :: n_basis = 2 ! P1 elements have 2 basis functions
+        integer :: element_type = 1 ! 1=P1
     contains
         procedure :: init => init_basis_1d
         procedure :: n_dofs => n_dofs_basis_1d
         procedure :: evaluate => evaluate_basis_1d
         procedure :: evaluate_derivative => evaluate_derivative_1d
     end type basis_1d_t
-    
+
 contains
 
     function p1_basis(i, xi) result(phi)
-        integer, intent(in) :: i      ! Basis function index (1 or 2)
-        real(dp), intent(in) :: xi    ! Local coordinate in [0,1]
+        integer, intent(in) :: i ! Basis function index (1 or 2)
+        real(dp), intent(in) :: xi ! Local coordinate in [0,1]
         real(dp) :: phi
-        
+
         select case(i)
         case(1)
             phi = 1.0_dp - xi
@@ -30,17 +30,17 @@ contains
         case default
             error stop "Invalid basis function index"
         end select
-        
+
     end function p1_basis
-    
+
     function p1_basis_derivative(i, xi) result(dphi)
-        integer, intent(in) :: i      ! Basis function index (1 or 2)
-        real(dp), intent(in) :: xi    ! Local coordinate (not used for P1)
+        integer, intent(in) :: i ! Basis function index (1 or 2)
+        real(dp), intent(in) :: xi ! Local coordinate (not used for P1)
         real(dp) :: dphi
-        
+
         associate(dummy => xi)
         end associate
-        
+
         select case(i)
         case(1)
             dphi = -1.0_dp
@@ -49,17 +49,17 @@ contains
         case default
             error stop "Invalid basis function index"
         end select
-        
+
     end function p1_basis_derivative
 
     subroutine init_basis_1d(this, mesh)
         use mesh_1d, only: mesh_1d_t
         class(basis_1d_t), intent(inout) :: this
         type(mesh_1d_t), intent(in) :: mesh
-        
+
         associate(dummy => mesh)
         end associate
-        
+
         this%n_basis = 2
         this%element_type = 1
     end subroutine init_basis_1d
@@ -75,10 +75,10 @@ contains
         integer, intent(in) :: i
         real(dp), intent(in) :: xi
         real(dp) :: phi
-        
+
         associate(dummy => this)
         end associate
-        
+
         phi = p1_basis(i, xi)
     end function evaluate_basis_1d
 
@@ -87,10 +87,10 @@ contains
         integer, intent(in) :: i
         real(dp), intent(in) :: xi
         real(dp) :: dphi
-        
+
         associate(dummy => this)
         end associate
-        
+
         dphi = p1_basis_derivative(i, xi)
     end function evaluate_derivative_1d
 

--- a/src/fortfem_api_forms.f90
+++ b/src/fortfem_api_forms.f90
@@ -62,17 +62,17 @@ contains
         type(form_expr_t) :: expr_a, expr_b
 
         select type(a)
-        type is (trial_function_t)
+            type is (trial_function_t)
             expr_a = create_grad("u", "trial")
-        type is (test_function_t)
+            type is (test_function_t)
             expr_a = create_grad("v", "test")
-        type is (vector_trial_function_t)
+            type is (vector_trial_function_t)
             expr_a = create_grad("E", "trial")
-        type is (vector_test_function_t)
+            type is (vector_test_function_t)
             expr_a = create_grad("F", "test")
-        type is (vector_function_t)
+            type is (vector_function_t)
             expr_a = create_grad("j", "function")
-        type is (form_expr_t)
+            type is (form_expr_t)
             expr_a = a
         class default
             expr_a%description = "unknown"
@@ -80,17 +80,17 @@ contains
         end select
 
         select type(b)
-        type is (trial_function_t)
+            type is (trial_function_t)
             expr_b = create_grad("u", "trial")
-        type is (test_function_t)
+            type is (test_function_t)
             expr_b = create_grad("v", "test")
-        type is (vector_trial_function_t)
+            type is (vector_trial_function_t)
             expr_b = create_grad("E", "trial")
-        type is (vector_test_function_t)
+            type is (vector_test_function_t)
             expr_b = create_grad("F", "test")
-        type is (vector_function_t)
+            type is (vector_function_t)
             expr_b = create_grad("j", "function")
-        type is (form_expr_t)
+            type is (form_expr_t)
             expr_b = b
         class default
             expr_b%description = "unknown"
@@ -105,9 +105,9 @@ contains
         type(form_expr_t) :: gradu
 
         select type(u)
-        type is (trial_function_t)
+            type is (trial_function_t)
             gradu = create_grad("u", "trial")
-        type is (test_function_t)
+            type is (test_function_t)
             gradu = create_grad("v", "test")
         class default
             gradu = create_grad("unknown", "unknown")
@@ -119,10 +119,10 @@ contains
         type(form_expr_t) :: curlu
 
         select type(u)
-        type is (vector_trial_function_t)
+            type is (vector_trial_function_t)
             curlu = create_grad("curl(u)", "trial")
             curlu%description = "curl(u)"
-        type is (vector_test_function_t)
+            type is (vector_test_function_t)
             curlu = create_grad("curl(v)", "test")
             curlu%description = "curl(v)"
         class default

--- a/src/fortfem_api_mesh.f90
+++ b/src/fortfem_api_mesh.f90
@@ -3,8 +3,8 @@ module fortfem_api_mesh
     use fortfem_mesh_2d, only: mesh_2d_t
     use fortfem_boundary, only: boundary_t
     use fortfem_api_mesh_boundaries, only: circle_boundary, &
-                                           rectangle_boundary, line_segment, &
-                                               arc_segment, l_shape_boundary
+        rectangle_boundary, line_segment, &
+        arc_segment, l_shape_boundary
     use triangle_io, only: read_triangle_mesh
     use fortfem_api_types, only: mesh_t, function_t
     use fortfem_api_forms, only: init_measures
@@ -53,12 +53,12 @@ contains
 
         do e = 1, mesh%data%n_triangles
             call compute_element_gradient_indicator(mesh, solution, e, &
-                                                    indicators(e))
+                indicators(e))
         end do
     end subroutine compute_gradient_indicators
 
     pure subroutine compute_element_gradient_indicator(mesh, solution, &
-                                                       element_index, indicator)
+            element_index, indicator)
         type(mesh_t), intent(in) :: mesh
         type(function_t), intent(in) :: solution
         integer, intent(in) :: element_index
@@ -82,7 +82,7 @@ contains
         y3 = mesh%data%vertices(2, v3)
 
         call compute_p1_gradient_shape_functions(x1, y1, x2, y2, x3, y3, &
-                                                 b, c, is_degenerate)
+            b, c, is_degenerate)
 
         if (is_degenerate) then
             indicator = 0.0_dp
@@ -100,7 +100,7 @@ contains
     end subroutine compute_element_gradient_indicator
 
     pure subroutine compute_p1_gradient_shape_functions(x1, y1, x2, y2, &
-                                                        x3, y3, b, c, is_degenerate)
+            x3, y3, b, c, is_degenerate)
         real(dp), intent(in) :: x1, y1, x2, y2, x3, y3
         real(dp), intent(out) :: b(3), c(3)
         logical, intent(out) :: is_degenerate
@@ -132,8 +132,8 @@ contains
         call init_measures()
 
         call mesh%data%create_rectangular(nx=n, ny=n, &
-                                          x_min=0.0_dp, x_max=1.0_dp, &
-                                          y_min=0.0_dp, y_max=1.0_dp)
+            x_min=0.0_dp, x_max=1.0_dp, &
+            y_min=0.0_dp, y_max=1.0_dp)
         call mesh%data%build_connectivity()
         call mesh%data%find_boundary()
     end function unit_square_mesh
@@ -145,8 +145,8 @@ contains
 
         call init_measures()
         call mesh%data%create_rectangular(nx=nx, ny=ny, &
-                                          x_min=domain(1), x_max=domain(2), &
-                                          y_min=domain(3), y_max=domain(4))
+            x_min=domain(1), x_max=domain(2), &
+            y_min=domain(3), y_max=domain(4))
         call mesh%data%build_connectivity()
         call mesh%data%find_boundary()
     end function rectangle_mesh
@@ -188,7 +188,7 @@ contains
         call init_measures()
 
         call set_triangle_mesh_metadata(mesh, size(vertices, 2), &
-                                        size(triangles, 2))
+            size(triangles, 2))
 
         allocate (mesh%data%vertices(2, mesh%data%n_vertices))
         allocate (mesh%data%triangles(3, mesh%data%n_triangles))
@@ -211,7 +211,7 @@ contains
         call init_measures()
 
         call read_triangle_mesh(basename, vertices, triangles, &
-                                n_vertices, n_triangles, stat)
+            n_vertices, n_triangles, stat)
 
         if (stat /= 0) then
             mesh%data%n_vertices = 0
@@ -234,7 +234,7 @@ contains
     end function mesh_from_triangle_files
 
     pure subroutine set_triangle_mesh_metadata(mesh, n_vertices, &
-                                               n_triangles)
+            n_triangles)
         type(mesh_t), intent(inout) :: mesh
         integer, intent(in) :: n_vertices, n_triangles
 
@@ -247,11 +247,11 @@ contains
     end subroutine set_triangle_mesh_metadata
 
     function mesh_from_domain(vertices, segments, hole_points, min_angle) &
-        result(mesh)
+            result(mesh)
         use triangulation_fortran, only: triangulation_result_t, &
-                                         triangulate_with_hole_fortran, &
-                                         triangulate_with_quality_fortran, &
-                                         cleanup_triangulation
+            triangulate_with_hole_fortran, &
+            triangulate_with_quality_fortran, &
+            cleanup_triangulation
         real(dp), intent(in) :: vertices(:, :)
         integer, intent(in) :: segments(:, :)
         real(dp), intent(in), optional :: hole_points(:, :)
@@ -269,10 +269,10 @@ contains
 
         if (present(hole_points)) then
             call triangulate_with_hole_fortran(vertices, segments, &
-                                               hole_points, result, stat)
+                hole_points, result, stat)
         else
             call triangulate_with_quality_fortran(vertices, segments, &
-                                                  angle, result, stat)
+                angle, result, stat)
         end if
 
         if (result%ntriangles == 0) then
@@ -282,7 +282,7 @@ contains
         end if
 
         call set_triangle_mesh_metadata(mesh, result%npoints, &
-                                        result%ntriangles)
+            result%ntriangles)
 
         allocate (mesh%data%vertices(2, mesh%data%n_vertices))
         allocate (mesh%data%triangles(3, mesh%data%n_triangles))
@@ -340,7 +340,7 @@ contains
     end function refine_adaptive_markers
 
     function refine_adaptive_solution(mesh, solution, tolerance) &
-        result(refined_mesh)
+            result(refined_mesh)
         type(mesh_t), intent(in) :: mesh
         type(function_t), intent(in) :: solution
         real(dp), intent(in) :: tolerance
@@ -402,10 +402,10 @@ contains
                 mesh%edges(2, i) == e1_v2) then
                 edge1 = i
             else if (mesh%edges(1, i) == e2_v1 .and. &
-                     mesh%edges(2, i) == e2_v2) then
+                    mesh%edges(2, i) == e2_v2) then
                 edge2 = i
             else if (mesh%edges(1, i) == e3_v1 .and. &
-                     mesh%edges(2, i) == e3_v2) then
+                    mesh%edges(2, i) == e3_v2) then
                 edge3 = i
             end if
         end do

--- a/src/fortfem_api_mesh_boundaries.f90
+++ b/src/fortfem_api_mesh_boundaries.f90
@@ -142,7 +142,7 @@ contains
 
         do i = 1, n
             angle = theta1 + dtheta*real(i - 1, dp)/ &
-                    real(max(n - 1, 1), dp)
+                real(max(n - 1, 1), dp)
             boundary%points(1, i) = center(1) + radius*cos(angle)
             boundary%points(2, i) = center(2) + radius*sin(angle)
         end do
@@ -168,24 +168,24 @@ contains
         idx = 0
 
         call add_l_shape_segment(boundary%points, idx, n_per_segment, &
-                                 0.0_dp, 0.0_dp, s, 0.0_dp)
+            0.0_dp, 0.0_dp, s, 0.0_dp)
         call add_l_shape_segment(boundary%points, idx, n_per_segment, &
-                                 s, 0.0_dp, 0.0_dp, s)
+            s, 0.0_dp, 0.0_dp, s)
         call add_l_shape_segment(boundary%points, idx, n_per_segment, &
-                                 s, s, s, 0.0_dp)
+            s, s, s, 0.0_dp)
         call add_l_shape_segment(boundary%points, idx, n_per_segment, &
-                                 2.0_dp*s, s, 0.0_dp, s)
+            2.0_dp*s, s, 0.0_dp, s)
         call add_l_shape_segment(boundary%points, idx, n_per_segment, &
-                                 2.0_dp*s, 2.0_dp*s, -2.0_dp*s, 0.0_dp)
+            2.0_dp*s, 2.0_dp*s, -2.0_dp*s, 0.0_dp)
         call add_l_shape_segment(boundary%points, idx, n_per_segment, &
-                                 0.0_dp, 2.0_dp*s, 0.0_dp, -2.0_dp*s)
+            0.0_dp, 2.0_dp*s, 0.0_dp, -2.0_dp*s)
 
         boundary%labels = 1
         boundary%is_closed = .true.
     end function l_shape_boundary
 
     pure subroutine add_l_shape_segment(points, idx, n_per_segment, &
-                                        start_x, start_y, dx, dy)
+            start_x, start_y, dx, dy)
         real(dp), intent(inout) :: points(:, :)
         integer, intent(inout) :: idx
         integer, intent(in) :: n_per_segment

--- a/src/fortfem_api_plot.f90
+++ b/src/fortfem_api_plot.f90
@@ -1,217 +1,217 @@
 module fortfem_api_plot
-   use fortfem_kinds
-   use fortfem_api_types, only: function_t, vector_function_t, mesh_t
-   use fortfem_api_plot_interpolation, only: compute_scalar_plot_grid, &
-                                             compute_vector_plot_grid
-   use fortfem_api_plot_mesh, only: prepare_mesh_plot, save_mesh_figure
-   implicit none
+    use fortfem_kinds
+    use fortfem_api_types, only: function_t, vector_function_t, mesh_t
+    use fortfem_api_plot_interpolation, only: compute_scalar_plot_grid, &
+        compute_vector_plot_grid
+    use fortfem_api_plot_mesh, only: prepare_mesh_plot, save_mesh_figure
+    implicit none
 
-   private
+    private
 
-   public :: plot
-   public :: plot_function_scalar
-   public :: plot_vector_function
-   public :: plot_mesh
+    public :: plot
+    public :: plot_function_scalar
+    public :: plot_vector_function
+    public :: plot_mesh
 
-   interface plot
-      module procedure plot_function_scalar
-      module procedure plot_vector_function
-      module procedure plot_mesh
-   end interface plot
+    interface plot
+        module procedure plot_function_scalar
+        module procedure plot_vector_function
+        module procedure plot_mesh
+    end interface plot
 
 contains
 
-   subroutine plot_function_scalar(uh, filename, title, colormap)
-      use fortplot, only: figure, contour_filled, xlabel, ylabel, &
-                          plot_title => title, savefig, pcolormesh, add_plot
-      type(function_t), intent(in) :: uh
-      character(len=*), intent(in), optional :: filename
-      character(len=*), intent(in), optional :: title
-      character(len=*), intent(in), optional :: colormap
+    subroutine plot_function_scalar(uh, filename, title, colormap)
+        use fortplot, only: figure, contour_filled, xlabel, ylabel, &
+            plot_title => title, savefig, pcolormesh, add_plot
+        type(function_t), intent(in) :: uh
+        character(len=*), intent(in), optional :: filename
+        character(len=*), intent(in), optional :: title
+        character(len=*), intent(in), optional :: colormap
 
-      integer, parameter :: nx = 40, ny = 40
-      real(dp) :: x_grid(nx + 1)
-      real(dp) :: y_grid(ny + 1)
-      real(dp) :: z_grid(nx, ny)
-      character(len=64) :: output_filename
-      character(len=128) :: title_text
-      character(len=32) :: cmap
+        integer, parameter :: nx = 40, ny = 40
+        real(dp) :: x_grid(nx + 1)
+        real(dp) :: y_grid(ny + 1)
+        real(dp) :: z_grid(nx, ny)
+        character(len=64) :: output_filename
+        character(len=128) :: title_text
+        character(len=32) :: cmap
 
-      call resolve_plot_filename_and_title(filename, title, "solution.png", &
-                                           "FEM Solution", output_filename, &
-                                           title_text)
+        call resolve_plot_filename_and_title(filename, title, "solution.png", &
+            "FEM Solution", output_filename, &
+            title_text)
 
-      if (present(colormap)) then
-         cmap = colormap
-      else
-         cmap = "viridis"
-      end if
+        if (present(colormap)) then
+            cmap = colormap
+        else
+            cmap = "viridis"
+        end if
 
-      call compute_scalar_plot_grid(uh, nx, ny, x_grid, y_grid, z_grid)
+        call compute_scalar_plot_grid(uh, nx, ny, x_grid, y_grid, z_grid)
 
-      call render_scalar_solution(uh, x_grid, y_grid, z_grid, title_text, &
-                                  cmap, output_filename)
-   end subroutine plot_function_scalar
+        call render_scalar_solution(uh, x_grid, y_grid, z_grid, title_text, &
+            cmap, output_filename)
+    end subroutine plot_function_scalar
 
-   subroutine plot_vector_function(Eh, filename, title, plot_type)
-      use fortplot, only: figure, streamplot, xlabel, ylabel, &
-                          plot_title => title, savefig
-      type(vector_function_t), intent(in) :: Eh
-      character(len=*), intent(in), optional :: filename
-      character(len=*), intent(in), optional :: title
-      character(len=*), intent(in), optional :: plot_type
+    subroutine plot_vector_function(Eh, filename, title, plot_type)
+        use fortplot, only: figure, streamplot, xlabel, ylabel, &
+            plot_title => title, savefig
+        type(vector_function_t), intent(in) :: Eh
+        character(len=*), intent(in), optional :: filename
+        character(len=*), intent(in), optional :: title
+        character(len=*), intent(in), optional :: plot_type
 
-      integer, parameter :: nx = 20, ny = 20
-      real(dp) :: x_grid(nx)
-      real(dp) :: y_grid(ny)
-      real(dp) :: u_grid(nx, ny)
-      real(dp) :: v_grid(nx, ny)
-      character(len=64) :: output_filename
-      character(len=128) :: title_text
-      character(len=32) :: ptype
+        integer, parameter :: nx = 20, ny = 20
+        real(dp) :: x_grid(nx)
+        real(dp) :: y_grid(ny)
+        real(dp) :: u_grid(nx, ny)
+        real(dp) :: v_grid(nx, ny)
+        character(len=64) :: output_filename
+        character(len=128) :: title_text
+        character(len=32) :: ptype
 
-      call resolve_plot_filename_and_title(filename, title, &
-                                           "vector_solution.png", &
-                                           "Vector FEM Solution", &
-                                           output_filename, title_text)
+        call resolve_plot_filename_and_title(filename, title, &
+            "vector_solution.png", &
+            "Vector FEM Solution", &
+            output_filename, title_text)
 
-      if (present(plot_type)) then
-         ptype = plot_type
-      else
-         ptype = "streamplot"
-      end if
+        if (present(plot_type)) then
+            ptype = plot_type
+        else
+            ptype = "streamplot"
+        end if
 
-      call compute_vector_plot_grid(Eh, nx, ny, x_grid, y_grid, u_grid, &
-                                    v_grid)
+        call compute_vector_plot_grid(Eh, nx, ny, x_grid, y_grid, u_grid, &
+            v_grid)
 
-      call render_vector_solution(x_grid, y_grid, u_grid, v_grid, &
-                                  title_text, ptype, output_filename)
-   end subroutine plot_vector_function
+        call render_vector_solution(x_grid, y_grid, u_grid, v_grid, &
+            title_text, ptype, output_filename)
+    end subroutine plot_vector_function
 
-   subroutine plot_mesh(mesh, filename, title, show_labels)
-      use fortplot_figure, only: figure_t
-      type(mesh_t), intent(inout) :: mesh
-      character(len=*), intent(in), optional :: filename
-      character(len=*), intent(in), optional :: title
-      logical, intent(in), optional :: show_labels
+    subroutine plot_mesh(mesh, filename, title, show_labels)
+        use fortplot_figure, only: figure_t
+        type(mesh_t), intent(inout) :: mesh
+        character(len=*), intent(in), optional :: filename
+        character(len=*), intent(in), optional :: title
+        logical, intent(in), optional :: show_labels
 
-      type(figure_t) :: fig
-      character(len=64) :: output_filename
-      character(len=128) :: title_text
-      logical :: labels
+        type(figure_t) :: fig
+        character(len=64) :: output_filename
+        character(len=128) :: title_text
+        logical :: labels
 
-      call resolve_plot_filename_and_title(filename, title, "mesh.png", &
-                                           "FEM Mesh", output_filename, title_text)
+        call resolve_plot_filename_and_title(filename, title, "mesh.png", &
+            "FEM Mesh", output_filename, title_text)
 
-      if (present(show_labels)) then
-         labels = show_labels
-      else
-         labels = .false.
-      end if
+        if (present(show_labels)) then
+            labels = show_labels
+        else
+            labels = .false.
+        end if
 
-      call prepare_mesh_plot(mesh, fig, labels, title_text)
+        call prepare_mesh_plot(mesh, fig, labels, title_text)
 
-      call save_mesh_figure(fig, mesh, output_filename)
-   end subroutine plot_mesh
+        call save_mesh_figure(fig, mesh, output_filename)
+    end subroutine plot_mesh
 
-   subroutine resolve_plot_filename_and_title(filename, title, default_filename, &
-                                              default_title, output_filename, &
-                                              title_text)
-      character(len=*), intent(in), optional :: filename
-      character(len=*), intent(in), optional :: title
-      character(len=*), intent(in) :: default_filename
-      character(len=*), intent(in) :: default_title
-      character(len=*), intent(out) :: output_filename
-      character(len=*), intent(out) :: title_text
+    subroutine resolve_plot_filename_and_title(filename, title, default_filename, &
+            default_title, output_filename, &
+            title_text)
+        character(len=*), intent(in), optional :: filename
+        character(len=*), intent(in), optional :: title
+        character(len=*), intent(in) :: default_filename
+        character(len=*), intent(in) :: default_title
+        character(len=*), intent(out) :: output_filename
+        character(len=*), intent(out) :: title_text
 
-      if (present(filename)) then
-         output_filename = filename
-      else
-         output_filename = default_filename
-      end if
+        if (present(filename)) then
+            output_filename = filename
+        else
+            output_filename = default_filename
+        end if
 
-      if (present(title)) then
-         title_text = title
-      else
-         title_text = default_title
-      end if
-   end subroutine resolve_plot_filename_and_title
+        if (present(title)) then
+            title_text = title
+        else
+            title_text = default_title
+        end if
+    end subroutine resolve_plot_filename_and_title
 
-   subroutine render_scalar_solution(uh, x_grid, y_grid, z_grid, &
-                                     title_text, cmap, output_filename)
-      use fortplot, only: figure, contour_filled, xlabel, ylabel, &
-                          plot_title => title, savefig, pcolormesh, add_plot
-      type(function_t), intent(in) :: uh
-      real(dp), intent(in) :: x_grid(:)
-      real(dp), intent(in) :: y_grid(:)
-      real(dp), intent(in) :: z_grid(:, :)
-      character(len=*), intent(in) :: title_text
-      character(len=*), intent(in) :: cmap
-      character(len=*), intent(in) :: output_filename
+    subroutine render_scalar_solution(uh, x_grid, y_grid, z_grid, &
+            title_text, cmap, output_filename)
+        use fortplot, only: figure, contour_filled, xlabel, ylabel, &
+            plot_title => title, savefig, pcolormesh, add_plot
+        type(function_t), intent(in) :: uh
+        real(dp), intent(in) :: x_grid(:)
+        real(dp), intent(in) :: y_grid(:)
+        real(dp), intent(in) :: z_grid(:, :)
+        character(len=*), intent(in) :: title_text
+        character(len=*), intent(in) :: cmap
+        character(len=*), intent(in) :: output_filename
 
-      real(dp) :: x_edges(2), y_edges(2)
-      real(dp), parameter :: black(3) = [0.0_dp, 0.0_dp, 0.0_dp]
-      integer :: v1, v2, e
+        real(dp) :: x_edges(2), y_edges(2)
+        real(dp), parameter :: black(3) = [0.0_dp, 0.0_dp, 0.0_dp]
+        integer :: v1, v2, e
 
-      call figure()
-      call plot_title(trim(title_text))
-      call xlabel("x")
-      call ylabel("y")
-      call pcolormesh(x_grid, y_grid, z_grid, colormap=trim(cmap))
+        call figure()
+        call plot_title(trim(title_text))
+        call xlabel("x")
+        call ylabel("y")
+        call pcolormesh(x_grid, y_grid, z_grid, colormap=trim(cmap))
 
-      if (.not. allocated(uh%space%mesh%data%edges)) then
-         call uh%space%mesh%data%build_connectivity()
-      end if
+        if (.not. allocated(uh%space%mesh%data%edges)) then
+            call uh%space%mesh%data%build_connectivity()
+        end if
 
-      do e = 1, uh%space%mesh%data%n_edges
-         v1 = uh%space%mesh%data%edges(1, e)
-         v2 = uh%space%mesh%data%edges(2, e)
+        do e = 1, uh%space%mesh%data%n_edges
+            v1 = uh%space%mesh%data%edges(1, e)
+            v2 = uh%space%mesh%data%edges(2, e)
 
-         x_edges(1) = uh%space%mesh%data%vertices(1, v1)
-         x_edges(2) = uh%space%mesh%data%vertices(1, v2)
-         y_edges(1) = uh%space%mesh%data%vertices(2, v1)
-         y_edges(2) = uh%space%mesh%data%vertices(2, v2)
+            x_edges(1) = uh%space%mesh%data%vertices(1, v1)
+            x_edges(2) = uh%space%mesh%data%vertices(1, v2)
+            y_edges(1) = uh%space%mesh%data%vertices(2, v1)
+            y_edges(2) = uh%space%mesh%data%vertices(2, v2)
 
-         call add_plot(x_edges, y_edges, color=black)
-      end do
+            call add_plot(x_edges, y_edges, color=black)
+        end do
 
-      call savefig(trim(output_filename))
+        call savefig(trim(output_filename))
 
-      write (*, *) "Plot saved to: ", trim(output_filename)
-      write (*, *) "Solution range: [", minval(uh%values), ",", &
-         maxval(uh%values), "]"
-   end subroutine render_scalar_solution
+        write (*, *) "Plot saved to: ", trim(output_filename)
+        write (*, *) "Solution range: [", minval(uh%values), ",", &
+            maxval(uh%values), "]"
+    end subroutine render_scalar_solution
 
-   subroutine render_vector_solution(x_grid, y_grid, u_grid, v_grid, &
-                                     title_text, ptype, output_filename)
-      use fortplot, only: figure, streamplot, xlabel, ylabel, &
-                          plot_title => title, savefig
-      real(dp), intent(in) :: x_grid(:)
-      real(dp), intent(in) :: y_grid(:)
-      real(dp), intent(in) :: u_grid(:, :)
-      real(dp), intent(in) :: v_grid(:, :)
-      character(len=*), intent(in) :: title_text
-      character(len=*), intent(in) :: ptype
-      character(len=*), intent(in) :: output_filename
+    subroutine render_vector_solution(x_grid, y_grid, u_grid, v_grid, &
+            title_text, ptype, output_filename)
+        use fortplot, only: figure, streamplot, xlabel, ylabel, &
+            plot_title => title, savefig
+        real(dp), intent(in) :: x_grid(:)
+        real(dp), intent(in) :: y_grid(:)
+        real(dp), intent(in) :: u_grid(:, :)
+        real(dp), intent(in) :: v_grid(:, :)
+        character(len=*), intent(in) :: title_text
+        character(len=*), intent(in) :: ptype
+        character(len=*), intent(in) :: output_filename
 
-      call figure()
-      call plot_title(trim(title_text))
-      call xlabel("x")
-      call ylabel("y")
+        call figure()
+        call plot_title(trim(title_text))
+        call xlabel("x")
+        call ylabel("y")
 
-      select case (trim(ptype))
-      case ("streamplot")
-         call streamplot(x_grid, y_grid, u_grid, v_grid)
-      case default
-         call streamplot(x_grid, y_grid, u_grid, v_grid)
-      end select
+        select case (trim(ptype))
+        case ("streamplot")
+            call streamplot(x_grid, y_grid, u_grid, v_grid)
+        case default
+            call streamplot(x_grid, y_grid, u_grid, v_grid)
+        end select
 
-      call savefig(trim(output_filename))
+        call savefig(trim(output_filename))
 
-      write (*, *) "Vector plot saved to: ", trim(output_filename)
-      write (*, *) "Vector magnitude range: [", &
-         minval(sqrt(u_grid**2 + v_grid**2)), ",", &
-         maxval(sqrt(u_grid**2 + v_grid**2)), "]"
-   end subroutine render_vector_solution
+        write (*, *) "Vector plot saved to: ", trim(output_filename)
+        write (*, *) "Vector magnitude range: [", &
+            minval(sqrt(u_grid**2 + v_grid**2)), ",", &
+            maxval(sqrt(u_grid**2 + v_grid**2)), "]"
+    end subroutine render_vector_solution
 
 end module fortfem_api_plot

--- a/src/fortfem_api_plot_interpolation.f90
+++ b/src/fortfem_api_plot_interpolation.f90
@@ -1,279 +1,279 @@
 module fortfem_api_plot_interpolation
-   use fortfem_kinds, only: dp
-   use fortfem_api_types, only: function_t, vector_function_t
-   implicit none
+    use fortfem_kinds, only: dp
+    use fortfem_api_types, only: function_t, vector_function_t
+    implicit none
 
-   private
+    private
 
-   public :: compute_scalar_plot_grid
-   public :: compute_vector_plot_grid
+    public :: compute_scalar_plot_grid
+    public :: compute_vector_plot_grid
 
 contains
 
-   subroutine compute_scalar_plot_grid(uh, nx, ny, x_grid, y_grid, z_grid)
-      type(function_t), intent(in) :: uh
-      integer, intent(in) :: nx, ny
-      real(dp), intent(out) :: x_grid(:)
-      real(dp), intent(out) :: y_grid(:)
-      real(dp), intent(out) :: z_grid(:, :)
+    subroutine compute_scalar_plot_grid(uh, nx, ny, x_grid, y_grid, z_grid)
+        type(function_t), intent(in) :: uh
+        integer, intent(in) :: nx, ny
+        real(dp), intent(out) :: x_grid(:)
+        real(dp), intent(out) :: y_grid(:)
+        real(dp), intent(out) :: z_grid(:, :)
 
-      real(dp) :: x_min, x_max, y_min, y_max, dx_grid, dy_grid
-      integer :: i, j
+        real(dp) :: x_min, x_max, y_min, y_max, dx_grid, dy_grid
+        integer :: i, j
 
-      x_min = minval(uh%space%mesh%data%vertices(1, :))
-      x_max = maxval(uh%space%mesh%data%vertices(1, :))
-      y_min = minval(uh%space%mesh%data%vertices(2, :))
-      y_max = maxval(uh%space%mesh%data%vertices(2, :))
+        x_min = minval(uh%space%mesh%data%vertices(1, :))
+        x_max = maxval(uh%space%mesh%data%vertices(1, :))
+        y_min = minval(uh%space%mesh%data%vertices(2, :))
+        y_max = maxval(uh%space%mesh%data%vertices(2, :))
 
-      dx_grid = (x_max - x_min)/real(nx, dp)
-      dy_grid = (y_max - y_min)/real(ny, dp)
+        dx_grid = (x_max - x_min)/real(nx, dp)
+        dy_grid = (y_max - y_min)/real(ny, dp)
 
-      do i = 1, nx + 1
-         x_grid(i) = x_min + real(i - 1, dp)*dx_grid
-      end do
+        do i = 1, nx + 1
+            x_grid(i) = x_min + real(i - 1, dp)*dx_grid
+        end do
 
-      do j = 1, ny + 1
-         y_grid(j) = y_min + real(j - 1, dp)*dy_grid
-      end do
+        do j = 1, ny + 1
+            y_grid(j) = y_min + real(j - 1, dp)*dy_grid
+        end do
 
-      if (uh%space%mesh%data%n_triangles > 0) then
-         call interpolate_to_grid(uh, x_grid(1:nx), y_grid(1:ny), z_grid)
-      else if (uh%space%mesh%data%n_quads > 0) then
-         call interpolate_quad_to_grid(uh, x_grid(1:nx), y_grid(1:ny), &
-                                       z_grid)
-      else
-         z_grid = 0.0_dp
-      end if
-   end subroutine compute_scalar_plot_grid
+        if (uh%space%mesh%data%n_triangles > 0) then
+            call interpolate_to_grid(uh, x_grid(1:nx), y_grid(1:ny), z_grid)
+        else if (uh%space%mesh%data%n_quads > 0) then
+            call interpolate_quad_to_grid(uh, x_grid(1:nx), y_grid(1:ny), &
+                z_grid)
+        else
+            z_grid = 0.0_dp
+        end if
+    end subroutine compute_scalar_plot_grid
 
-   subroutine compute_vector_plot_grid(Eh, nx, ny, x_grid, y_grid, u_grid, &
-                                       v_grid)
-      type(vector_function_t), intent(in) :: Eh
-      integer, intent(in) :: nx, ny
-      real(dp), intent(out) :: x_grid(:)
-      real(dp), intent(out) :: y_grid(:)
-      real(dp), intent(out) :: u_grid(:, :)
-      real(dp), intent(out) :: v_grid(:, :)
+    subroutine compute_vector_plot_grid(Eh, nx, ny, x_grid, y_grid, u_grid, &
+            v_grid)
+        type(vector_function_t), intent(in) :: Eh
+        integer, intent(in) :: nx, ny
+        real(dp), intent(out) :: x_grid(:)
+        real(dp), intent(out) :: y_grid(:)
+        real(dp), intent(out) :: u_grid(:, :)
+        real(dp), intent(out) :: v_grid(:, :)
 
-      real(dp) :: x_min, x_max, y_min, y_max, dx_grid, dy_grid
-      integer :: i, j
+        real(dp) :: x_min, x_max, y_min, y_max, dx_grid, dy_grid
+        integer :: i, j
 
-      x_min = minval(Eh%space%mesh%data%vertices(1, :))
-      x_max = maxval(Eh%space%mesh%data%vertices(1, :))
-      y_min = minval(Eh%space%mesh%data%vertices(2, :))
-      y_max = maxval(Eh%space%mesh%data%vertices(2, :))
+        x_min = minval(Eh%space%mesh%data%vertices(1, :))
+        x_max = maxval(Eh%space%mesh%data%vertices(1, :))
+        y_min = minval(Eh%space%mesh%data%vertices(2, :))
+        y_max = maxval(Eh%space%mesh%data%vertices(2, :))
 
-      dx_grid = (x_max - x_min)/real(nx - 1, dp)
-      dy_grid = (y_max - y_min)/real(ny - 1, dp)
+        dx_grid = (x_max - x_min)/real(nx - 1, dp)
+        dy_grid = (y_max - y_min)/real(ny - 1, dp)
 
-      do i = 1, nx
-         x_grid(i) = x_min + real(i - 1, dp)*dx_grid
-      end do
+        do i = 1, nx
+            x_grid(i) = x_min + real(i - 1, dp)*dx_grid
+        end do
 
-      do j = 1, ny
-         y_grid(j) = y_min + real(j - 1, dp)*dy_grid
-      end do
+        do j = 1, ny
+            y_grid(j) = y_min + real(j - 1, dp)*dy_grid
+        end do
 
-      call interpolate_vector_to_grid(Eh, x_grid, y_grid, u_grid, v_grid)
-   end subroutine compute_vector_plot_grid
+        call interpolate_vector_to_grid(Eh, x_grid, y_grid, u_grid, v_grid)
+    end subroutine compute_vector_plot_grid
 
-   subroutine interpolate_to_grid(uh, x_grid, y_grid, z_grid)
-      type(function_t), intent(in) :: uh
-      real(dp), intent(in) :: x_grid(:), y_grid(:)
-      real(dp), intent(out) :: z_grid(:, :)
+    subroutine interpolate_to_grid(uh, x_grid, y_grid, z_grid)
+        type(function_t), intent(in) :: uh
+        real(dp), intent(in) :: x_grid(:), y_grid(:)
+        real(dp), intent(out) :: z_grid(:, :)
 
-      integer :: i, j, e, v1, v2, v3
-      real(dp) :: x, y, x1, y1, x2, y2, x3, y3
-      real(dp) :: lambda1, lambda2, lambda3, val
-      logical :: found
+        integer :: i, j, e, v1, v2, v3
+        real(dp) :: x, y, x1, y1, x2, y2, x3, y3
+        real(dp) :: lambda1, lambda2, lambda3, val
+        logical :: found
 
-      do i = 1, size(x_grid)
-         do j = 1, size(y_grid)
-            x = x_grid(i)
-            y = y_grid(j)
-            found = .false.
+        do i = 1, size(x_grid)
+            do j = 1, size(y_grid)
+                x = x_grid(i)
+                y = y_grid(j)
+                found = .false.
 
-            do e = 1, uh%space%mesh%data%n_triangles
-               if (found) exit
+                do e = 1, uh%space%mesh%data%n_triangles
+                    if (found) exit
 
-               v1 = uh%space%mesh%data%triangles(1, e)
-               v2 = uh%space%mesh%data%triangles(2, e)
-               v3 = uh%space%mesh%data%triangles(3, e)
+                    v1 = uh%space%mesh%data%triangles(1, e)
+                    v2 = uh%space%mesh%data%triangles(2, e)
+                    v3 = uh%space%mesh%data%triangles(3, e)
 
-               x1 = uh%space%mesh%data%vertices(1, v1)
-               y1 = uh%space%mesh%data%vertices(2, v1)
-               x2 = uh%space%mesh%data%vertices(1, v2)
-               y2 = uh%space%mesh%data%vertices(2, v2)
-               x3 = uh%space%mesh%data%vertices(1, v3)
-               y3 = uh%space%mesh%data%vertices(2, v3)
+                    x1 = uh%space%mesh%data%vertices(1, v1)
+                    y1 = uh%space%mesh%data%vertices(2, v1)
+                    x2 = uh%space%mesh%data%vertices(1, v2)
+                    y2 = uh%space%mesh%data%vertices(2, v2)
+                    x3 = uh%space%mesh%data%vertices(1, v3)
+                    y3 = uh%space%mesh%data%vertices(2, v3)
 
-               call barycentric_coordinates(x, y, x1, y1, x2, y2, &
-                                            x3, y3, lambda1, &
-                                            lambda2, lambda3)
+                    call barycentric_coordinates(x, y, x1, y1, x2, y2, &
+                        x3, y3, lambda1, &
+                        lambda2, lambda3)
 
-               if (lambda1 >= -1.0e-10_dp .and. &
-                   lambda2 >= -1.0e-10_dp .and. &
-                   lambda3 >= -1.0e-10_dp) then
-                  val = lambda1*uh%values(v1) + &
-                        lambda2*uh%values(v2) + &
-                        lambda3*uh%values(v3)
-                  z_grid(i, j) = val
-                  found = .true.
-               end if
+                    if (lambda1 >= -1.0e-10_dp .and. &
+                        lambda2 >= -1.0e-10_dp .and. &
+                        lambda3 >= -1.0e-10_dp) then
+                        val = lambda1*uh%values(v1) + &
+                            lambda2*uh%values(v2) + &
+                            lambda3*uh%values(v3)
+                        z_grid(i, j) = val
+                        found = .true.
+                    end if
+                end do
+
+                if (.not. found) then
+                    z_grid(i, j) = find_nearest_value(uh, x, y)
+                end if
             end do
+        end do
+    end subroutine interpolate_to_grid
 
-            if (.not. found) then
-               z_grid(i, j) = find_nearest_value(uh, x, y)
+    subroutine interpolate_quad_to_grid(uh, x_grid, y_grid, z_grid)
+        type(function_t), intent(in) :: uh
+        real(dp), intent(in) :: x_grid(:), y_grid(:)
+        real(dp), intent(out) :: z_grid(:, :)
+
+        integer :: i, j
+
+        z_grid = 0.0_dp
+
+        do i = 1, size(x_grid)
+            do j = 1, size(y_grid)
+                z_grid(i, j) = interpolate_quad_value(uh, x_grid(i), &
+                    y_grid(j))
+            end do
+        end do
+    end subroutine interpolate_quad_to_grid
+
+    subroutine interpolate_vector_to_grid(Eh, x_grid, y_grid, u_grid, v_grid)
+        type(vector_function_t), intent(in) :: Eh
+        real(dp), intent(in) :: x_grid(:), y_grid(:)
+        real(dp), intent(out) :: u_grid(:, :), v_grid(:, :)
+
+        integer :: i, j
+        real(dp) :: x, y
+
+        do i = 1, size(x_grid)
+            do j = 1, size(y_grid)
+                x = x_grid(i)
+                y = y_grid(j)
+
+                if (i <= size(x_grid)/2 .and. j <= size(y_grid)/2) then
+                    u_grid(i, j) = x*y
+                    v_grid(i, j) = x*x
+                else
+                    u_grid(i, j) = 0.1_dp*x
+                    v_grid(i, j) = 0.1_dp*y
+                end if
+            end do
+        end do
+    end subroutine interpolate_vector_to_grid
+
+    subroutine barycentric_coordinates(x, y, x1, y1, x2, y2, x3, y3, &
+            lambda1, lambda2, lambda3)
+        real(dp), intent(in) :: x, y, x1, y1, x2, y2, x3, y3
+        real(dp), intent(out) :: lambda1, lambda2, lambda3
+
+        real(dp) :: denom
+
+        denom = (y2 - y3)*(x1 - x3) + (x3 - x2)*(y1 - y3)
+
+        if (abs(denom) < 1.0e-14_dp) then
+            lambda1 = -1.0_dp
+            lambda2 = -1.0_dp
+            lambda3 = -1.0_dp
+        else
+            lambda1 = ((y2 - y3)*(x - x3) + (x3 - x2)*(y - y3))/denom
+            lambda2 = ((y3 - y1)*(x - x3) + (x1 - x3)*(y - y3))/denom
+            lambda3 = 1.0_dp - lambda1 - lambda2
+        end if
+    end subroutine barycentric_coordinates
+
+    pure function find_nearest_value(uh, x, y) result(val)
+        type(function_t), intent(in) :: uh
+        real(dp), intent(in) :: x, y
+        real(dp) :: val
+
+        integer :: i, nearest_vertex
+        real(dp) :: min_dist, dist, vx, vy
+
+        min_dist = huge(1.0_dp)
+        nearest_vertex = 1
+
+        do i = 1, uh%space%mesh%data%n_vertices
+            vx = uh%space%mesh%data%vertices(1, i)
+            vy = uh%space%mesh%data%vertices(2, i)
+            dist = (x - vx)**2 + (y - vy)**2
+
+            if (dist < min_dist) then
+                min_dist = dist
+                nearest_vertex = i
             end if
-         end do
-      end do
-   end subroutine interpolate_to_grid
+        end do
 
-   subroutine interpolate_quad_to_grid(uh, x_grid, y_grid, z_grid)
-      type(function_t), intent(in) :: uh
-      real(dp), intent(in) :: x_grid(:), y_grid(:)
-      real(dp), intent(out) :: z_grid(:, :)
+        val = uh%values(nearest_vertex)
+    end function find_nearest_value
 
-      integer :: i, j
+    pure subroutine quad_shape_functions(xi_ref, eta_ref, N)
+        real(dp), intent(in) :: xi_ref, eta_ref
+        real(dp), intent(out) :: N(4)
 
-      z_grid = 0.0_dp
+        N(1) = 0.25_dp*(1.0_dp - xi_ref)*(1.0_dp - eta_ref)
+        N(2) = 0.25_dp*(1.0_dp + xi_ref)*(1.0_dp - eta_ref)
+        N(3) = 0.25_dp*(1.0_dp + xi_ref)*(1.0_dp + eta_ref)
+        N(4) = 0.25_dp*(1.0_dp - xi_ref)*(1.0_dp + eta_ref)
+    end subroutine quad_shape_functions
 
-      do i = 1, size(x_grid)
-         do j = 1, size(y_grid)
-            z_grid(i, j) = interpolate_quad_value(uh, x_grid(i), &
-                                                  y_grid(j))
-         end do
-      end do
-   end subroutine interpolate_quad_to_grid
+    pure function interpolate_quad_value(uh, x, y) result(val)
+        type(function_t), intent(in) :: uh
+        real(dp), intent(in) :: x, y
+        real(dp) :: val
 
-   subroutine interpolate_vector_to_grid(Eh, x_grid, y_grid, u_grid, v_grid)
-      type(vector_function_t), intent(in) :: Eh
-      real(dp), intent(in) :: x_grid(:), y_grid(:)
-      real(dp), intent(out) :: u_grid(:, :), v_grid(:, :)
+        integer :: q, k, vi
+        integer :: v_ids(4)
+        real(dp) :: x1, y1, x2, y2
+        real(dp) :: xc, yc, xi_ref, eta_ref
+        real(dp) :: N(4)
+        logical :: found
 
-      integer :: i, j
-      real(dp) :: x, y
+        val = 0.0_dp
+        found = .false.
 
-      do i = 1, size(x_grid)
-         do j = 1, size(y_grid)
-            x = x_grid(i)
-            y = y_grid(j)
+        do q = 1, uh%space%mesh%data%n_quads
+            v_ids = uh%space%mesh%data%quads(:, q)
 
-            if (i <= size(x_grid)/2 .and. j <= size(y_grid)/2) then
-               u_grid(i, j) = x*y
-               v_grid(i, j) = x*x
-            else
-               u_grid(i, j) = 0.1_dp*x
-               v_grid(i, j) = 0.1_dp*y
+            x1 = uh%space%mesh%data%vertices(1, v_ids(1))
+            y1 = uh%space%mesh%data%vertices(2, v_ids(1))
+            x2 = uh%space%mesh%data%vertices(1, v_ids(3))
+            y2 = uh%space%mesh%data%vertices(2, v_ids(3))
+
+            if (x >= x1 .and. x <= x2 .and. y >= y1 .and. y <= y2) then
+                if (x2 > x1 .and. y2 > y1) then
+                    xc = 0.5_dp*(x1 + x2)
+                    yc = 0.5_dp*(y1 + y2)
+
+                    xi_ref = 2.0_dp*(x - xc)/(x2 - x1)
+                    eta_ref = 2.0_dp*(y - yc)/(y2 - y1)
+
+                    call quad_shape_functions(xi_ref, eta_ref, N)
+
+                    val = 0.0_dp
+                    do k = 1, 4
+                        vi = v_ids(k)
+                        val = val + N(k)*uh%values(vi)
+                    end do
+
+                    found = .true.
+                end if
             end if
-         end do
-      end do
-   end subroutine interpolate_vector_to_grid
 
-   subroutine barycentric_coordinates(x, y, x1, y1, x2, y2, x3, y3, &
-                                      lambda1, lambda2, lambda3)
-      real(dp), intent(in) :: x, y, x1, y1, x2, y2, x3, y3
-      real(dp), intent(out) :: lambda1, lambda2, lambda3
+            if (found) exit
+        end do
 
-      real(dp) :: denom
-
-      denom = (y2 - y3)*(x1 - x3) + (x3 - x2)*(y1 - y3)
-
-      if (abs(denom) < 1.0e-14_dp) then
-         lambda1 = -1.0_dp
-         lambda2 = -1.0_dp
-         lambda3 = -1.0_dp
-      else
-         lambda1 = ((y2 - y3)*(x - x3) + (x3 - x2)*(y - y3))/denom
-         lambda2 = ((y3 - y1)*(x - x3) + (x1 - x3)*(y - y3))/denom
-         lambda3 = 1.0_dp - lambda1 - lambda2
-      end if
-   end subroutine barycentric_coordinates
-
-   pure function find_nearest_value(uh, x, y) result(val)
-      type(function_t), intent(in) :: uh
-      real(dp), intent(in) :: x, y
-      real(dp) :: val
-
-      integer :: i, nearest_vertex
-      real(dp) :: min_dist, dist, vx, vy
-
-      min_dist = huge(1.0_dp)
-      nearest_vertex = 1
-
-      do i = 1, uh%space%mesh%data%n_vertices
-         vx = uh%space%mesh%data%vertices(1, i)
-         vy = uh%space%mesh%data%vertices(2, i)
-         dist = (x - vx)**2 + (y - vy)**2
-
-         if (dist < min_dist) then
-            min_dist = dist
-            nearest_vertex = i
-         end if
-      end do
-
-      val = uh%values(nearest_vertex)
-   end function find_nearest_value
-
-   pure subroutine quad_shape_functions(xi_ref, eta_ref, N)
-      real(dp), intent(in) :: xi_ref, eta_ref
-      real(dp), intent(out) :: N(4)
-
-      N(1) = 0.25_dp*(1.0_dp - xi_ref)*(1.0_dp - eta_ref)
-      N(2) = 0.25_dp*(1.0_dp + xi_ref)*(1.0_dp - eta_ref)
-      N(3) = 0.25_dp*(1.0_dp + xi_ref)*(1.0_dp + eta_ref)
-      N(4) = 0.25_dp*(1.0_dp - xi_ref)*(1.0_dp + eta_ref)
-   end subroutine quad_shape_functions
-
-   pure function interpolate_quad_value(uh, x, y) result(val)
-      type(function_t), intent(in) :: uh
-      real(dp), intent(in) :: x, y
-      real(dp) :: val
-
-      integer :: q, k, vi
-      integer :: v_ids(4)
-      real(dp) :: x1, y1, x2, y2
-      real(dp) :: xc, yc, xi_ref, eta_ref
-      real(dp) :: N(4)
-      logical :: found
-
-      val = 0.0_dp
-      found = .false.
-
-      do q = 1, uh%space%mesh%data%n_quads
-         v_ids = uh%space%mesh%data%quads(:, q)
-
-         x1 = uh%space%mesh%data%vertices(1, v_ids(1))
-         y1 = uh%space%mesh%data%vertices(2, v_ids(1))
-         x2 = uh%space%mesh%data%vertices(1, v_ids(3))
-         y2 = uh%space%mesh%data%vertices(2, v_ids(3))
-
-         if (x >= x1 .and. x <= x2 .and. y >= y1 .and. y <= y2) then
-            if (x2 > x1 .and. y2 > y1) then
-               xc = 0.5_dp*(x1 + x2)
-               yc = 0.5_dp*(y1 + y2)
-
-               xi_ref = 2.0_dp*(x - xc)/(x2 - x1)
-               eta_ref = 2.0_dp*(y - yc)/(y2 - y1)
-
-               call quad_shape_functions(xi_ref, eta_ref, N)
-
-               val = 0.0_dp
-               do k = 1, 4
-                  vi = v_ids(k)
-                  val = val + N(k)*uh%values(vi)
-               end do
-
-               found = .true.
-            end if
-         end if
-
-         if (found) exit
-      end do
-
-      if (.not. found) then
-         val = find_nearest_value(uh, x, y)
-      end if
-   end function interpolate_quad_value
+        if (.not. found) then
+            val = find_nearest_value(uh, x, y)
+        end if
+    end function interpolate_quad_value
 
 end module fortfem_api_plot_interpolation

--- a/src/fortfem_api_plot_mesh.f90
+++ b/src/fortfem_api_plot_mesh.f90
@@ -1,91 +1,91 @@
 module fortfem_api_plot_mesh
-   use fortfem_kinds, only: dp
-   use fortfem_api_types, only: mesh_t
-   use fortplot_figure, only: figure_t
-   implicit none
+    use fortfem_kinds, only: dp
+    use fortfem_api_types, only: mesh_t
+    use fortplot_figure, only: figure_t
+    implicit none
 
-   private
+    private
 
-   public :: prepare_mesh_plot
-   public :: save_mesh_figure
+    public :: prepare_mesh_plot
+    public :: save_mesh_figure
 
 contains
 
-   subroutine prepare_mesh_plot(mesh, fig, labels, title_text)
-      type(mesh_t), intent(inout) :: mesh
-      type(figure_t), intent(inout) :: fig
-      logical, intent(in) :: labels
-      character(len=*), intent(in) :: title_text
+    subroutine prepare_mesh_plot(mesh, fig, labels, title_text)
+        type(mesh_t), intent(inout) :: mesh
+        type(figure_t), intent(inout) :: fig
+        logical, intent(in) :: labels
+        character(len=*), intent(in) :: title_text
 
-      real(dp), allocatable :: x_tri(:), y_tri(:)
-      integer :: ntri_plot
-      real(dp) :: x_min, x_max, y_min, y_max, margin
+        real(dp), allocatable :: x_tri(:), y_tri(:)
+        integer :: ntri_plot
+        real(dp) :: x_min, x_max, y_min, y_max, margin
 
-      x_min = minval(mesh%data%vertices(1, :))
-      x_max = maxval(mesh%data%vertices(1, :))
-      y_min = minval(mesh%data%vertices(2, :))
-      y_max = maxval(mesh%data%vertices(2, :))
-      margin = 0.1_dp*max(x_max - x_min, y_max - y_min)
+        x_min = minval(mesh%data%vertices(1, :))
+        x_max = maxval(mesh%data%vertices(1, :))
+        y_min = minval(mesh%data%vertices(2, :))
+        y_max = maxval(mesh%data%vertices(2, :))
+        margin = 0.1_dp*max(x_max - x_min, y_max - y_min)
 
-      call fig%initialize()
+        call fig%initialize()
 
-      if (.not. allocated(mesh%data%triangles)) then
-         call mesh%data%build_connectivity()
-      end if
+        if (.not. allocated(mesh%data%triangles)) then
+            call mesh%data%build_connectivity()
+        end if
 
-      allocate (x_tri(4), y_tri(4))
+        allocate (x_tri(4), y_tri(4))
 
-      ntri_plot = min(mesh%data%n_triangles, fig%state%max_plots)
-      call add_mesh_triangles_to_figure(mesh, fig, ntri_plot, x_tri, y_tri)
+        ntri_plot = min(mesh%data%n_triangles, fig%state%max_plots)
+        call add_mesh_triangles_to_figure(mesh, fig, ntri_plot, x_tri, y_tri)
 
-      call fig%set_xlabel("x")
-      call fig%set_ylabel("y")
-      call fig%set_title(trim(title_text))
+        call fig%set_xlabel("x")
+        call fig%set_ylabel("y")
+        call fig%set_title(trim(title_text))
 
-      call fig%set_xlim(x_min - margin, x_max + margin)
-      call fig%set_ylim(y_min - margin, y_max + margin)
+        call fig%set_xlim(x_min - margin, x_max + margin)
+        call fig%set_ylim(y_min - margin, y_max + margin)
 
-      deallocate (x_tri, y_tri)
-   end subroutine prepare_mesh_plot
+        deallocate (x_tri, y_tri)
+    end subroutine prepare_mesh_plot
 
-   subroutine add_mesh_triangles_to_figure(mesh, fig, ntri_plot, x_tri, y_tri)
-      type(mesh_t), intent(in) :: mesh
-      type(figure_t), intent(inout) :: fig
-      integer, intent(in) :: ntri_plot
-      real(dp), intent(inout) :: x_tri(:), y_tri(:)
+    subroutine add_mesh_triangles_to_figure(mesh, fig, ntri_plot, x_tri, y_tri)
+        type(mesh_t), intent(in) :: mesh
+        type(figure_t), intent(inout) :: fig
+        integer, intent(in) :: ntri_plot
+        real(dp), intent(inout) :: x_tri(:), y_tri(:)
 
-      integer :: t, v1, v2, v3
+        integer :: t, v1, v2, v3
 
-      do t = 1, ntri_plot
-         v1 = mesh%data%triangles(1, t)
-         v2 = mesh%data%triangles(2, t)
-         v3 = mesh%data%triangles(3, t)
+        do t = 1, ntri_plot
+            v1 = mesh%data%triangles(1, t)
+            v2 = mesh%data%triangles(2, t)
+            v3 = mesh%data%triangles(3, t)
 
-         x_tri(1) = mesh%data%vertices(1, v1)
-         y_tri(1) = mesh%data%vertices(2, v1)
-         x_tri(2) = mesh%data%vertices(1, v2)
-         y_tri(2) = mesh%data%vertices(2, v2)
-         x_tri(3) = mesh%data%vertices(1, v3)
-         y_tri(3) = mesh%data%vertices(2, v3)
-         x_tri(4) = x_tri(1)
-         y_tri(4) = y_tri(1)
+            x_tri(1) = mesh%data%vertices(1, v1)
+            y_tri(1) = mesh%data%vertices(2, v1)
+            x_tri(2) = mesh%data%vertices(1, v2)
+            y_tri(2) = mesh%data%vertices(2, v2)
+            x_tri(3) = mesh%data%vertices(1, v3)
+            y_tri(3) = mesh%data%vertices(2, v3)
+            x_tri(4) = x_tri(1)
+            y_tri(4) = y_tri(1)
 
-         call fig%add_plot(x_tri, y_tri)
-      end do
-   end subroutine add_mesh_triangles_to_figure
+            call fig%add_plot(x_tri, y_tri)
+        end do
+    end subroutine add_mesh_triangles_to_figure
 
-   subroutine save_mesh_figure(fig, mesh, output_filename)
-      type(figure_t), intent(inout) :: fig
-      type(mesh_t), intent(in) :: mesh
-      character(len=*), intent(in) :: output_filename
+    subroutine save_mesh_figure(fig, mesh, output_filename)
+        type(figure_t), intent(inout) :: fig
+        type(mesh_t), intent(in) :: mesh
+        character(len=*), intent(in) :: output_filename
 
-      call fig%savefig(trim(output_filename))
+        call fig%savefig(trim(output_filename))
 
-      write (*, *) "Mesh plot saved to: ", trim(output_filename)
-      write (*, *) "Mesh info:"
-      write (*, *) "  Vertices: ", mesh%data%n_vertices
-      write (*, *) "  Triangles: ", mesh%data%n_triangles
-      write (*, *) "  Edges: ", mesh%data%n_edges
-   end subroutine save_mesh_figure
+        write (*, *) "Mesh plot saved to: ", trim(output_filename)
+        write (*, *) "Mesh info:"
+        write (*, *) "  Vertices: ", mesh%data%n_vertices
+        write (*, *) "  Triangles: ", mesh%data%n_triangles
+        write (*, *) "  Edges: ", mesh%data%n_edges
+    end subroutine save_mesh_figure
 
 end module fortfem_api_plot_mesh

--- a/src/fortfem_api_solvers_vector.f90
+++ b/src/fortfem_api_solvers_vector.f90
@@ -170,7 +170,7 @@ contains
     end subroutine add_curl_curl_triangle
 
     subroutine accumulate_curl_curl_for_edges(edge1, edge2, edge3, ndof, &
-        area, A, b)
+            area, A, b)
         integer, intent(in) :: edge1, edge2, edge3, ndof
         real(dp), intent(in) :: area
         real(dp), intent(inout) :: A(:, :), b(:)

--- a/src/fortfem_api_spaces.f90
+++ b/src/fortfem_api_spaces.f90
@@ -169,7 +169,7 @@ contains
     end function neumann_bc_constant
 
     function neumann_bc_on_boundary(space, flux_value, boundary_part)       &
-        result(bc)
+            result(bc)
         type(function_space_t), target, intent(in) :: space
         real(dp), intent(in) :: flux_value
         character(len=*), intent(in) :: boundary_part
@@ -183,7 +183,7 @@ contains
     end function neumann_bc_on_boundary
 
     function dirichlet_bc_on_boundary(space, value, boundary_part)          &
-        result(bc)
+            result(bc)
         type(function_space_t), target, intent(in) :: space
         real(dp), intent(in) :: value
         character(len=*), intent(in) :: boundary_part

--- a/src/fortfem_boundary.f90
+++ b/src/fortfem_boundary.f90
@@ -2,16 +2,16 @@ module fortfem_boundary
     ! Boundary representation for mesh generation
     use fortfem_kinds
     implicit none
-    
+
     private
     public :: boundary_t
-    
+
     ! Boundary type for defining domains
     type :: boundary_t
         integer :: n_points = 0
-        real(dp), allocatable :: points(:,:)     ! (2, n_points)
-        integer, allocatable :: labels(:)       ! (n_points-1) segment labels
+        real(dp), allocatable :: points(:,:) ! (2, n_points)
+        integer, allocatable :: labels(:) ! (n_points-1) segment labels
         logical :: is_closed = .false.
     end type boundary_t
-    
+
 end module fortfem_boundary

--- a/src/fortfem_forms_simple.f90
+++ b/src/fortfem_forms_simple.f90
@@ -2,53 +2,53 @@ module fortfem_forms_simple
     ! Simplified forms system for mathematical expressions
     use fortfem_kinds
     implicit none
-    
+
     private
     public :: form_expr_t, create_grad, create_inner, compile_form
-    
+
     ! Simple form expression type
     type :: form_expr_t
         character(len=128) :: description = ""
-        character(len=32) :: form_type = ""  ! "bilinear", "linear", "functional"
+        character(len=32) :: form_type = "" ! "bilinear", "linear", "functional"
         integer :: tensor_rank = 0
     contains
         procedure :: destroy => form_expr_destroy
     end type form_expr_t
-    
+
 contains
 
     function create_grad(func_name, func_type) result(expr)
         character(len=*), intent(in) :: func_name, func_type
         type(form_expr_t) :: expr
-        
+
         expr%description = "grad(" // trim(func_name) // ")"
         expr%form_type = func_type
         expr%tensor_rank = 1
     end function create_grad
-    
+
     function create_inner(a, b) result(expr)
         type(form_expr_t), intent(in) :: a, b
         type(form_expr_t) :: expr
-        
+
         expr%description = "inner(" // trim(a%description) // ", " // trim(b%description) // ")"
         expr%tensor_rank = 0
-        
+
         ! Determine form type
         if ((trim(a%form_type) == "trial" .or. trim(a%form_type) == "bilinear") .and. &
             (trim(b%form_type) == "test" .or. trim(b%form_type) == "bilinear")) then
             expr%form_type = "bilinear"
         else if (trim(a%form_type) == "test" .or. trim(b%form_type) == "test" .or. &
-                 trim(a%form_type) == "function" .or. trim(b%form_type) == "function") then
+                trim(a%form_type) == "function" .or. trim(b%form_type) == "function") then
             expr%form_type = "linear"
         else
             expr%form_type = "functional"
         end if
     end function create_inner
-    
+
     function compile_form(expr) result(assembly_code)
         type(form_expr_t), intent(in) :: expr
         character(len=256) :: assembly_code
-        
+
         select case (trim(expr%form_type))
         case ("bilinear")
             assembly_code = "assemble_bilinear(" // trim(expr%description) // ")"
@@ -58,7 +58,7 @@ contains
             assembly_code = "evaluate(" // trim(expr%description) // ")"
         end select
     end function compile_form
-    
+
     subroutine form_expr_destroy(this)
         class(form_expr_t), intent(inout) :: this
         ! Nothing to deallocate for simple strings

--- a/src/mesh/mesh_1d.f90
+++ b/src/mesh/mesh_1d.f90
@@ -2,17 +2,17 @@ module mesh_1d
     ! Simple 1D mesh generation
     use fortfem_kinds, only: dp
     implicit none
-    
+
     private
     public :: mesh_1d_t, create_interval, create_segments
-    
+
     type :: mesh_1d_t
         integer :: n_points = 0
-        real(dp), allocatable :: points(:)      ! (n_points)
-        integer, allocatable :: segments(:,:)   ! (2, n_segments)  
+        real(dp), allocatable :: points(:) ! (n_points)
+        integer, allocatable :: segments(:,:) ! (2, n_segments)
         integer :: n_segments = 0
     end type mesh_1d_t
-    
+
 contains
 
     subroutine create_interval(mesh, a, b, n)
@@ -20,66 +20,66 @@ contains
         type(mesh_1d_t), intent(out) :: mesh
         real(dp), intent(in) :: a, b
         integer, intent(in) :: n
-        
+
         integer :: i
         real(dp) :: dx
-        
+
         mesh%n_points = n
         mesh%n_segments = n - 1
-        
+
         allocate(mesh%points(n))
         allocate(mesh%segments(2, n-1))
-        
+
         ! Generate uniform points
         dx = (b - a) / real(n - 1, dp)
         do i = 1, n
             mesh%points(i) = a + (i - 1) * dx
         end do
-        
+
         ! Generate segments
         do i = 1, n - 1
             mesh%segments(1, i) = i
             mesh%segments(2, i) = i + 1
         end do
-        
+
     end subroutine create_interval
 
     subroutine create_segments(mesh, segment_points, densities)
         !> Create 1D mesh from multiple segments with different densities
         type(mesh_1d_t), intent(out) :: mesh
-        real(dp), intent(in) :: segment_points(:)   ! endpoints of segments
-        integer, intent(in) :: densities(:)         ! points per segment
-        
+        real(dp), intent(in) :: segment_points(:) ! endpoints of segments
+        integer, intent(in) :: densities(:) ! points per segment
+
         integer :: n_segments, total_points, i, j, idx
         real(dp) :: dx
-        
+
         n_segments = size(segment_points) - 1
-        total_points = sum(densities) - n_segments + 1  ! Account for shared endpoints
-        
+        total_points = sum(densities) - n_segments + 1 ! Account for shared endpoints
+
         mesh%n_points = total_points
         mesh%n_segments = total_points - 1
-        
+
         allocate(mesh%points(total_points))
         allocate(mesh%segments(2, mesh%n_segments))
-        
+
         ! Generate points
         idx = 1
         do i = 1, n_segments
             dx = (segment_points(i+1) - segment_points(i)) / real(densities(i) - 1, dp)
-            
+
             do j = 1, densities(i)
-                if (i > 1 .and. j == 1) cycle  ! Skip duplicate endpoint
+                if (i > 1 .and. j == 1) cycle ! Skip duplicate endpoint
                 mesh%points(idx) = segment_points(i) + (j - 1) * dx
                 idx = idx + 1
             end do
         end do
-        
+
         ! Generate segments
         do i = 1, mesh%n_segments
             mesh%segments(1, i) = i
             mesh%segments(2, i) = i + 1
         end do
-        
+
     end subroutine create_segments
 
 end module mesh_1d

--- a/src/mesh/mesh_2d.f90
+++ b/src/mesh/mesh_2d.f90
@@ -2,49 +2,49 @@ module fortfem_mesh_2d
     use fortfem_kinds
     implicit none
     private
-    
+
     type, public :: mesh_2d_t
         ! Vertices
         integer :: n_vertices = 0
-        real(dp), allocatable :: vertices(:,:)  ! (2, n_vertices) - x,y coordinates
-        
-        ! Triangles  
+        real(dp), allocatable :: vertices(:,:) ! (2, n_vertices) - x,y coordinates
+
+        ! Triangles
         integer :: n_triangles = 0
-        integer, allocatable :: triangles(:,:)  ! (3, n_triangles) - vertex indices
-        
+        integer, allocatable :: triangles(:,:) ! (3, n_triangles) - vertex indices
+
         ! Quadrilaterals
         integer :: n_quads = 0
-        integer, allocatable :: quads(:,:)      ! (4, n_quads) - vertex indices
-        
+        integer, allocatable :: quads(:,:) ! (4, n_quads) - vertex indices
+
         ! Element type flags
         logical :: has_triangles = .false.
         logical :: has_quads = .false.
         logical :: has_mixed_elements = .false.
-        
+
         ! Edges
         integer :: n_edges = 0
-        integer, allocatable :: edges(:,:)      ! (2, n_edges) - vertex indices
-        integer, allocatable :: edge_to_triangles(:,:)  ! (2, n_edges) - triangle indices
-        integer, allocatable :: edge_to_quads(:,:)     ! (2, n_edges) - quad indices
+        integer, allocatable :: edges(:,:) ! (2, n_edges) - vertex indices
+        integer, allocatable :: edge_to_triangles(:,:) ! (2, n_edges) - triangle indices
+        integer, allocatable :: edge_to_quads(:,:) ! (2, n_edges) - quad indices
         integer, allocatable :: edge_element_type(:,:) ! (2, n_edges) - element type (1=tri, 2=quad)
-        
+
         ! Edge DOF numbering for H(curl) elements
         integer :: n_edge_dofs = 0
-        integer, allocatable :: edge_to_dof(:)    ! (n_edges) - maps edge to DOF number
-        integer, allocatable :: dof_to_edge(:)    ! (n_edge_dofs) - maps DOF to edge number
+        integer, allocatable :: edge_to_dof(:) ! (n_edges) - maps edge to DOF number
+        integer, allocatable :: dof_to_edge(:) ! (n_edge_dofs) - maps DOF to edge number
         integer :: n_interior_dofs = 0
         integer :: n_boundary_dofs = 0
-        
+
         ! Boundary
         integer :: n_boundary_edges = 0
-        integer, allocatable :: boundary_edges(:)     ! Indices of boundary edges
+        integer, allocatable :: boundary_edges(:) ! Indices of boundary edges
         logical, allocatable :: is_boundary_vertex(:) ! Flag for boundary vertices
-        
+
         ! Connectivity
         type(sparse_int_list_t), allocatable :: vertex_to_triangles(:)
         type(sparse_int_list_t), allocatable :: vertex_to_quads(:)
         type(sparse_int_list_t), allocatable :: vertex_to_vertices(:)
-        
+
     contains
         procedure :: create_rectangular
         procedure :: create_unit_disk
@@ -66,11 +66,11 @@ module fortfem_mesh_2d
         procedure :: save_to_file
         procedure :: load_from_file
         procedure :: destroy
-        
+
         ! Mesh refinement procedures
         procedure :: refine_uniform => refine_mesh_uniform
         procedure :: refine_adaptive => refine_mesh_adaptive
-        
+
         ! Quadrilateral-specific procedures
         procedure :: create_structured_quads
         procedure :: get_quad_edges
@@ -78,23 +78,23 @@ module fortfem_mesh_2d
         procedure :: build_quad_connectivity
         procedure :: build_mixed_connectivity
     end type mesh_2d_t
-    
+
     ! Helper type for sparse connectivity
     type :: sparse_int_list_t
         integer :: n = 0
         integer, allocatable :: items(:)
     end type sparse_int_list_t
-    
+
 contains
 
     subroutine create_rectangular(this, nx, ny, x_min, x_max, y_min, y_max)
         class(mesh_2d_t), intent(out) :: this
-        integer, intent(in) :: nx, ny  ! Number of vertices in x,y directions
+        integer, intent(in) :: nx, ny ! Number of vertices in x,y directions
         real(dp), intent(in) :: x_min, x_max, y_min, y_max
-        
+
         integer :: i, j, k, v1, v2, v3, v4
         real(dp) :: dx, dy
-        
+
         ! Total vertices and triangles
         this%n_vertices = nx * ny
         this%n_triangles = 2 * (nx-1) * (ny-1)
@@ -102,15 +102,15 @@ contains
         this%has_triangles = .true.
         this%has_quads = .false.
         this%has_mixed_elements = .false.
-        
+
         ! Allocate arrays
         allocate(this%vertices(2, this%n_vertices))
         allocate(this%triangles(3, this%n_triangles))
-        
+
         ! Grid spacing
         dx = (x_max - x_min) / real(nx - 1, dp)
         dy = (y_max - y_min) / real(ny - 1, dp)
-        
+
         ! Create vertices
         k = 0
         do j = 1, ny
@@ -120,23 +120,23 @@ contains
                 this%vertices(2, k) = y_min + (j-1) * dy
             end do
         end do
-        
+
         ! Create triangles (each rectangle split into 2 triangles)
         k = 0
         do j = 1, ny-1
             do i = 1, nx-1
                 ! Vertices of rectangle
-                v1 = (j-1)*nx + i       ! bottom-left
-                v2 = (j-1)*nx + i + 1   ! bottom-right
-                v3 = j*nx + i + 1       ! top-right
-                v4 = j*nx + i           ! top-left
-                
+                v1 = (j-1)*nx + i ! bottom-left
+                v2 = (j-1)*nx + i + 1 ! bottom-right
+                v3 = j*nx + i + 1 ! top-right
+                v4 = j*nx + i ! top-left
+
                 ! Lower triangle
                 k = k + 1
                 this%triangles(1, k) = v1
                 this%triangles(2, k) = v2
                 this%triangles(3, k) = v3
-                
+
                 ! Upper triangle
                 k = k + 1
                 this%triangles(1, k) = v1
@@ -144,29 +144,29 @@ contains
                 this%triangles(3, k) = v4
             end do
         end do
-        
+
     end subroutine create_rectangular
-    
+
     subroutine build_connectivity(this)
         class(mesh_2d_t), intent(inout) :: this
-        
+
         integer :: t, v, i
         integer, allocatable :: temp_list(:)
-        
+
         ! Allocate connectivity arrays
         if (allocated(this%vertex_to_triangles)) deallocate(this%vertex_to_triangles)
         if (allocated(this%vertex_to_vertices)) deallocate(this%vertex_to_vertices)
-        
+
         allocate(this%vertex_to_triangles(this%n_vertices))
         allocate(this%vertex_to_vertices(this%n_vertices))
-        
+
         ! Build vertex-to-triangle connectivity when triangles are present
         if (this%n_triangles > 0) then
             allocate(temp_list(this%n_triangles))
-            
+
             do v = 1, this%n_vertices
                 this%vertex_to_triangles(v)%n = 0
-                
+
                 ! Count triangles containing this vertex
                 do t = 1, this%n_triangles
                     do i = 1, 3
@@ -177,7 +177,7 @@ contains
                         end if
                     end do
                 end do
-                
+
                 ! Store triangle list
                 if (this%vertex_to_triangles(v)%n > 0) then
                     allocate(this%vertex_to_triangles(v)%items( &
@@ -186,10 +186,10 @@ contains
                         1:this%vertex_to_triangles(v)%n)
                 end if
             end do
-            
+
             deallocate(temp_list)
         end if
-        
+
         ! Handle different element types for edge connectivity
         if (this%has_triangles .and. this%has_quads) then
             ! Mixed mesh: build unified edge connectivity
@@ -205,52 +205,52 @@ contains
             this%n_edges = 0
             if (allocated(this%edges)) deallocate(this%edges)
         end if
-        
+
     end subroutine build_connectivity
-    
+
     subroutine build_edge_connectivity(this)
         class(mesh_2d_t), intent(inout) :: this
-        
+
         ! Build edge connectivity for H(curl) finite elements
         ! This calls the existing build_connectivity but ensures edges are built
         call this%build_connectivity()
-        
+
         ! Ensure boundary edges are identified
         call this%find_boundary()
     end subroutine build_edge_connectivity
-    
+
     subroutine get_edge_vertices(this, edge_index, vertices)
         class(mesh_2d_t), intent(in) :: this
         integer, intent(in) :: edge_index
         integer, intent(out) :: vertices(2)
-        
+
         if (edge_index < 1 .or. edge_index > this%n_edges) then
             error stop "Edge index out of bounds"
         end if
-        
+
         if (.not. allocated(this%edges)) then
             error stop "Edge connectivity not built. Call build_edge_connectivity first"
         end if
-        
+
         vertices(1) = this%edges(1, edge_index)
         vertices(2) = this%edges(2, edge_index)
     end subroutine get_edge_vertices
-    
+
     function is_boundary_edge(this, edge_index) result(is_boundary)
         class(mesh_2d_t), intent(in) :: this
         integer, intent(in) :: edge_index
         logical :: is_boundary
-        
+
         integer :: i
-        
+
         if (edge_index < 1 .or. edge_index > this%n_edges) then
             error stop "Edge index out of bounds"
         end if
-        
+
         if (.not. allocated(this%boundary_edges)) then
             error stop "Boundary edges not identified. Call build_edge_connectivity first"
         end if
-        
+
         ! Check if edge is in boundary_edges array
         is_boundary = .false.
         do i = 1, this%n_boundary_edges
@@ -260,31 +260,31 @@ contains
             end if
         end do
     end function is_boundary_edge
-    
+
     subroutine get_edge_triangles(this, edge_index, triangles)
         class(mesh_2d_t), intent(in) :: this
         integer, intent(in) :: edge_index
         integer, allocatable, intent(out) :: triangles(:)
-        
+
         integer :: t, i, j, v1, v2, count
         integer, allocatable :: temp_triangles(:)
-        
+
         if (edge_index < 1 .or. edge_index > this%n_edges) then
             error stop "Edge index out of bounds"
         end if
-        
+
         if (.not. allocated(this%edges)) then
             error stop "Edge connectivity not built. Call build_edge_connectivity first"
         end if
-        
+
         ! Get edge vertices
         v1 = this%edges(1, edge_index)
         v2 = this%edges(2, edge_index)
-        
+
         ! Allocate temporary array for worst case
         allocate(temp_triangles(2))
         count = 0
-        
+
         ! Find triangles containing this edge
         do t = 1, this%n_triangles
             do i = 1, 3
@@ -300,41 +300,41 @@ contains
                 end if
             end do
         end do
-        
+
         ! Copy to output array
         allocate(triangles(count))
         triangles = temp_triangles(1:count)
-        
+
         deallocate(temp_triangles)
     end subroutine get_edge_triangles
-    
+
     subroutine get_edge_length_tangent(this, edge_index, length, tangent)
         class(mesh_2d_t), intent(in) :: this
         integer, intent(in) :: edge_index
         real(dp), intent(out) :: length, tangent(2)
-        
+
         integer :: v1, v2
         real(dp) :: dx, dy
-        
+
         if (edge_index < 1 .or. edge_index > this%n_edges) then
             error stop "Edge index out of bounds"
         end if
-        
+
         if (.not. allocated(this%edges)) then
             error stop "Edge connectivity not built. Call build_edge_connectivity first"
         end if
-        
+
         ! Get edge vertices
         v1 = this%edges(1, edge_index)
         v2 = this%edges(2, edge_index)
-        
+
         ! Compute edge vector
         dx = this%vertices(1, v2) - this%vertices(1, v1)
         dy = this%vertices(2, v2) - this%vertices(2, v1)
-        
+
         ! Compute edge length
         length = sqrt(dx**2 + dy**2)
-        
+
         ! Compute unit tangent vector
         if (length > 0.0_dp) then
             tangent(1) = dx / length
@@ -345,23 +345,23 @@ contains
             tangent(2) = 0.0_dp
         end if
     end subroutine get_edge_length_tangent
-    
+
     subroutine build_edge_dof_numbering(this)
         class(mesh_2d_t), intent(inout) :: this
-        
+
         integer :: i, dof_count
-        
+
         if (.not. allocated(this%edges)) then
             error stop "Edge connectivity not built. Call build_edge_connectivity first"
         end if
-        
+
         ! RT0/Nédélec lowest order: one DOF per edge
         this%n_edge_dofs = this%n_edges
-        
+
         ! Allocate DOF mapping arrays
         allocate(this%edge_to_dof(this%n_edges))
         allocate(this%dof_to_edge(this%n_edge_dofs))
-        
+
         ! Number interior DOFs first (0-based indexing)
         dof_count = 0
         do i = 1, this%n_edges
@@ -371,9 +371,9 @@ contains
                 dof_count = dof_count + 1
             end if
         end do
-        
+
         this%n_interior_dofs = dof_count
-        
+
         ! Number boundary DOFs next
         do i = 1, this%n_edges
             if (this%is_boundary_edge(i)) then
@@ -382,52 +382,52 @@ contains
                 dof_count = dof_count + 1
             end if
         end do
-        
+
         this%n_boundary_dofs = dof_count - this%n_interior_dofs
     end subroutine build_edge_dof_numbering
-    
+
     function get_n_edge_dofs(this) result(n_dofs)
         class(mesh_2d_t), intent(in) :: this
         integer :: n_dofs
-        
+
         n_dofs = this%n_edge_dofs
     end function get_n_edge_dofs
-    
+
     function get_last_interior_dof(this) result(last_dof)
         class(mesh_2d_t), intent(in) :: this
         integer :: last_dof
-        
+
         last_dof = this%n_interior_dofs - 1
     end function get_last_interior_dof
-    
+
     function get_first_boundary_dof(this) result(first_dof)
         class(mesh_2d_t), intent(in) :: this
         integer :: first_dof
-        
+
         first_dof = this%n_interior_dofs
     end function get_first_boundary_dof
-    
+
     subroutine get_triangle_edge_dofs(this, triangle_index, edge_dofs)
         class(mesh_2d_t), intent(in) :: this
         integer, intent(in) :: triangle_index
         integer, intent(out) :: edge_dofs(3)
-        
+
         integer :: i, j, v1, v2, edge_index
-        
+
         if (triangle_index < 1 .or. triangle_index > this%n_triangles) then
             error stop "Triangle index out of bounds"
         end if
-        
+
         if (.not. allocated(this%edge_to_dof)) then
             error stop "Edge DOF numbering not built. Call build_edge_dof_numbering first"
         end if
-        
+
         ! Find the 3 edges of this triangle
         do i = 1, 3
             j = mod(i, 3) + 1
             v1 = min(this%triangles(i, triangle_index), this%triangles(j, triangle_index))
             v2 = max(this%triangles(i, triangle_index), this%triangles(j, triangle_index))
-            
+
             ! Find this edge in the edge list
             edge_index = 0
             do edge_index = 1, this%n_edges
@@ -435,35 +435,35 @@ contains
                     exit
                 end if
             end do
-            
+
             if (edge_index > this%n_edges) then
                 error stop "Edge not found in triangle"
             end if
-            
+
             edge_dofs(i) = this%edge_to_dof(edge_index)
         end do
     end subroutine get_triangle_edge_dofs
-    
+
     subroutine build_edges_from_triangles(this)
         class(mesh_2d_t), intent(inout) :: this
-        
+
         integer :: t, i, j, v1, v2, e, found
         integer :: max_edges
         integer, allocatable :: temp_edges(:,:)
-        
+
         ! Maximum possible edges
         max_edges = 3 * this%n_triangles
         allocate(temp_edges(2, max_edges))
-        
+
         this%n_edges = 0
-        
+
         ! Extract unique edges from triangles
         do t = 1, this%n_triangles
             do i = 1, 3
                 j = mod(i, 3) + 1
                 v1 = min(this%triangles(i, t), this%triangles(j, t))
                 v2 = max(this%triangles(i, t), this%triangles(j, t))
-                
+
                 ! Check if edge already exists
                 found = 0
                 do e = 1, this%n_edges
@@ -472,7 +472,7 @@ contains
                         exit
                     end if
                 end do
-                
+
                 if (found == 0) then
                     this%n_edges = this%n_edges + 1
                     temp_edges(1, this%n_edges) = v1
@@ -480,43 +480,43 @@ contains
                 end if
             end do
         end do
-        
+
         ! Copy to final array
         allocate(this%edges(2, this%n_edges))
         this%edges = temp_edges(:, 1:this%n_edges)
-        
+
         deallocate(temp_edges)
-        
+
         ! Build edge-to-triangle mapping
         call this%build_edge_to_triangle_mapping()
-        
+
     end subroutine build_edges_from_triangles
-    
+
     subroutine build_edge_to_triangle_mapping(this)
         class(mesh_2d_t), intent(inout) :: this
-        
+
         integer :: t, i, j, v1, v2, e
         integer, allocatable :: edge_triangle_count(:)
-        
+
         if (.not. allocated(this%edges)) then
             error stop "Edges must be built before edge-to-triangle mapping"
         end if
-        
+
         ! Allocate edge-to-triangle mapping (2 triangles max per edge)
         allocate(this%edge_to_triangles(2, this%n_edges))
         allocate(edge_triangle_count(this%n_edges))
-        
+
         ! Initialize
         this%edge_to_triangles = 0
         edge_triangle_count = 0
-        
+
         ! For each triangle, find its edges and record the triangle-edge relationship
         do t = 1, this%n_triangles
             do i = 1, 3
                 j = mod(i, 3) + 1
                 v1 = min(this%triangles(i, t), this%triangles(j, t))
                 v2 = max(this%triangles(i, t), this%triangles(j, t))
-                
+
                 ! Find the edge with these vertices
                 do e = 1, this%n_edges
                     if (this%edges(1, e) == v1 .and. this%edges(2, e) == v2) then
@@ -533,46 +533,46 @@ contains
                 end do
             end do
         end do
-        
+
         deallocate(edge_triangle_count)
-        
+
     end subroutine build_edge_to_triangle_mapping
-    
+
     subroutine find_boundary(this)
         class(mesh_2d_t), intent(inout) :: this
-        
+
         integer :: e, v1, v2, count
         integer, allocatable :: temp_boundary(:)
-        
+
         if (.not. allocated(this%edges)) then
             error stop "Edges must be built before finding boundary"
         end if
-        
+
         allocate(temp_boundary(this%n_edges))
         if (.not. allocated(this%is_boundary_vertex)) then
             allocate(this%is_boundary_vertex(this%n_vertices))
         end if
         this%is_boundary_vertex = .false.
-        
+
         this%n_boundary_edges = 0
-        
+
         ! Boundary edges belong to exactly one element (triangle or quad)
         do e = 1, this%n_edges
             v1 = this%edges(1, e)
             v2 = this%edges(2, e)
-            
+
             count = 0
-            
+
             if (allocated(this%edge_to_triangles)) then
                 if (this%edge_to_triangles(1, e) > 0) count = count + 1
                 if (this%edge_to_triangles(2, e) > 0) count = count + 1
             end if
-            
+
             if (allocated(this%edge_to_quads)) then
                 if (this%edge_to_quads(1, e) > 0) count = count + 1
                 if (this%edge_to_quads(2, e) > 0) count = count + 1
             end if
-            
+
             if (count == 1) then
                 this%n_boundary_edges = this%n_boundary_edges + 1
                 temp_boundary(this%n_boundary_edges) = e
@@ -580,25 +580,25 @@ contains
                 this%is_boundary_vertex(v2) = .true.
             end if
         end do
-        
+
         ! Store boundary edges
         if (allocated(this%boundary_edges)) deallocate(this%boundary_edges)
         allocate(this%boundary_edges(this%n_boundary_edges))
         this%boundary_edges = temp_boundary(1:this%n_boundary_edges)
-        
+
         deallocate(temp_boundary)
-        
+
     end subroutine find_boundary
-    
+
     function compute_areas(this) result(areas)
         class(mesh_2d_t), intent(in) :: this
         real(dp), allocatable :: areas(:)
-        
+
         integer :: t
         real(dp) :: x1, y1, x2, y2, x3, y3
-        
+
         allocate(areas(this%n_triangles))
-        
+
         do t = 1, this%n_triangles
             x1 = this%vertices(1, this%triangles(1, t))
             y1 = this%vertices(2, this%triangles(1, t))
@@ -606,83 +606,83 @@ contains
             y2 = this%vertices(2, this%triangles(2, t))
             x3 = this%vertices(1, this%triangles(3, t))
             y3 = this%vertices(2, this%triangles(3, t))
-            
+
             ! Area = 0.5 * |det([[x1-x3, x2-x3], [y1-y3, y2-y3]])|
             areas(t) = 0.5_dp * abs((x1-x3)*(y2-y3) - (x2-x3)*(y1-y3))
         end do
-        
+
     end function compute_areas
-    
+
     subroutine save_to_file(this, filename)
         class(mesh_2d_t), intent(in) :: this
         character(len=*), intent(in) :: filename
-        
+
         integer :: unit, i
-        
+
         open(newunit=unit, file=filename, status='replace', action='write')
-        
+
         ! Write header
         write(unit, '(a)') '# FortFEM 2D Mesh'
         write(unit, '(a,i0)') '# Vertices: ', this%n_vertices
         write(unit, '(a,i0)') '# Triangles: ', this%n_triangles
-        
+
         ! Write vertices
         write(unit, '(a)') 'VERTICES'
         write(unit, '(i0)') this%n_vertices
         do i = 1, this%n_vertices
             write(unit, '(2(es23.16,1x))') this%vertices(:, i)
         end do
-        
+
         ! Write triangles
         write(unit, '(a)') 'TRIANGLES'
         write(unit, '(i0)') this%n_triangles
         do i = 1, this%n_triangles
             write(unit, '(3(i0,1x))') this%triangles(:, i)
         end do
-        
+
         close(unit)
-        
+
     end subroutine save_to_file
-    
+
     subroutine load_from_file(this, filename)
         class(mesh_2d_t), intent(out) :: this
         character(len=*), intent(in) :: filename
-        
+
         integer :: unit, i
         character(len=100) :: line
-        
+
         open(newunit=unit, file=filename, status='old', action='read')
-        
+
         ! Skip header
         do
             read(unit, '(a)') line
             if (line == 'VERTICES') exit
         end do
-        
+
         ! Read vertices
         read(unit, *) this%n_vertices
         allocate(this%vertices(2, this%n_vertices))
         do i = 1, this%n_vertices
             read(unit, *) this%vertices(:, i)
         end do
-        
+
         ! Read triangles
-        read(unit, '(a)') line  ! Should be 'TRIANGLES'
+        read(unit, '(a)') line ! Should be 'TRIANGLES'
         read(unit, *) this%n_triangles
         allocate(this%triangles(3, this%n_triangles))
         do i = 1, this%n_triangles
             read(unit, *) this%triangles(:, i)
         end do
-        
+
         close(unit)
-        
+
     end subroutine load_from_file
-    
+
     subroutine destroy(this)
         class(mesh_2d_t), intent(inout) :: this
-        
+
         integer :: i
-        
+
         if (allocated(this%vertices)) deallocate(this%vertices)
         if (allocated(this%triangles)) deallocate(this%triangles)
         if (allocated(this%quads)) deallocate(this%quads)
@@ -694,7 +694,7 @@ contains
         if (allocated(this%is_boundary_vertex)) deallocate(this%is_boundary_vertex)
         if (allocated(this%edge_to_dof)) deallocate(this%edge_to_dof)
         if (allocated(this%dof_to_edge)) deallocate(this%dof_to_edge)
-        
+
         if (allocated(this%vertex_to_triangles)) then
             do i = 1, size(this%vertex_to_triangles)
                 if (allocated(this%vertex_to_triangles(i)%items)) then
@@ -703,7 +703,7 @@ contains
             end do
             deallocate(this%vertex_to_triangles)
         end if
-        
+
         if (allocated(this%vertex_to_quads)) then
             do i = 1, size(this%vertex_to_quads)
                 if (allocated(this%vertex_to_quads(i)%items)) then
@@ -712,7 +712,7 @@ contains
             end do
             deallocate(this%vertex_to_quads)
         end if
-        
+
         if (allocated(this%vertex_to_vertices)) then
             do i = 1, size(this%vertex_to_vertices)
                 if (allocated(this%vertex_to_vertices(i)%items)) then
@@ -721,7 +721,7 @@ contains
             end do
             deallocate(this%vertex_to_vertices)
         end if
-        
+
         this%n_vertices = 0
         this%n_triangles = 0
         this%n_quads = 0
@@ -733,7 +733,7 @@ contains
         this%has_triangles = .false.
         this%has_quads = .false.
         this%has_mixed_elements = .false.
-        
+
     end subroutine destroy
 
     ! Clean mesh generation routines
@@ -741,25 +741,25 @@ contains
         use triangulator, only: triangulate_points
         class(mesh_2d_t), intent(out) :: this
         real(dp), intent(in) :: max_element_size
-        
+
         integer, parameter :: n_boundary = 16
         real(dp) :: boundary_points(2, n_boundary)
         real(dp), allocatable :: mesh_points(:,:)
         integer, allocatable :: mesh_triangles(:,:)
         integer :: n_points, n_triangles, i
         real(dp) :: theta
-        
+
         ! Generate unit circle boundary points
         do i = 1, n_boundary
             theta = 2.0_dp * acos(-1.0_dp) * (i-1) / n_boundary
             boundary_points(1, i) = cos(theta)
             boundary_points(2, i) = sin(theta)
         end do
-        
+
         ! Triangulate the boundary
         call triangulate_points(boundary_points, mesh_points, mesh_triangles, &
-                               n_points, n_triangles)
-        
+            n_points, n_triangles)
+
         ! Convert to mesh_2d_t format
         this%n_vertices = n_points
         this%n_triangles = n_triangles
@@ -767,13 +767,13 @@ contains
         this%has_triangles = .true.
         this%has_quads = .false.
         this%has_mixed_elements = .false.
-        
+
         allocate(this%vertices(2, n_points))
         allocate(this%triangles(3, n_triangles))
-        
+
         this%vertices = mesh_points
         this%triangles = mesh_triangles
-        
+
         deallocate(mesh_points, mesh_triangles)
     end subroutine create_unit_disk
 
@@ -783,7 +783,7 @@ contains
         class(mesh_2d_t), intent(out) :: this
         type(boundary_t), intent(in) :: boundary
         real(dp), intent(in) :: resolution
-        
+
         real(dp), allocatable :: mesh_points(:,:)
         integer, allocatable :: mesh_triangles(:,:), segments(:,:)
         integer :: n_points, n_triangles, i
@@ -791,9 +791,9 @@ contains
         real(dp) :: eps
         logical :: is_rectangle
         integer :: n_side
-        
+
         eps = 1.0e-10_dp
-        
+
         ! Special handling for simple axis-aligned rectangular boundaries:
         ! detect a closed rectangle and build a structured rectangular mesh
         if (boundary%is_closed .and. boundary%n_points > 0) then
@@ -801,18 +801,18 @@ contains
             x_max = maxval(boundary%points(1, :))
             y_min = minval(boundary%points(2, :))
             y_max = maxval(boundary%points(2, :))
-            
+
             is_rectangle = .true.
             do i = 1, boundary%n_points
                 x = boundary%points(1, i)
                 y = boundary%points(2, i)
                 if (.not. ((abs(x - x_min) < eps) .or. (abs(x - x_max) < eps) .or. &
-                           (abs(y - y_min) < eps) .or. (abs(y - y_max) < eps))) then
+                    (abs(y - y_min) < eps) .or. (abs(y - y_max) < eps))) then
                     is_rectangle = .false.
                     exit
                 end if
             end do
-            
+
             if (is_rectangle .and. mod(boundary%n_points, 4) == 0) then
                 n_side = boundary%n_points / 4
                 if (n_side >= 2) then
@@ -822,7 +822,7 @@ contains
                 end if
             end if
         end if
-        
+
         ! Generate segments from boundary points
         if (boundary%is_closed) then
             allocate(segments(2, boundary%n_points))
@@ -840,11 +840,11 @@ contains
                 segments(2, i) = i + 1
             end do
         end if
-        
+
         ! Triangulate the boundary for general shapes
         call triangulate_boundary(boundary%points, segments, mesh_points, &
-                                  mesh_triangles, n_points, n_triangles)
-        
+            mesh_triangles, n_points, n_triangles)
+
         ! Convert to mesh_2d_t format
         this%n_vertices = n_points
         this%n_triangles = n_triangles
@@ -852,42 +852,42 @@ contains
         this%has_triangles = .true.
         this%has_quads = .false.
         this%has_mixed_elements = .false.
-        
+
         allocate(this%vertices(2, n_points))
         allocate(this%triangles(3, n_triangles))
-        
+
         this%vertices = mesh_points
         this%triangles = mesh_triangles
-        
+
         deallocate(mesh_points, mesh_triangles, segments)
-        
+
     end subroutine create_from_boundary
 
     ! Mesh refinement implementations
-    
+
     ! Uniform red refinement: each triangle is divided into 4 subtriangles
     subroutine refine_mesh_uniform(this, refined_mesh)
         class(mesh_2d_t), intent(in) :: this
         class(mesh_2d_t), intent(out) :: refined_mesh
-        
+
         integer :: old_nv, old_nt, old_ne
         integer :: new_nv, new_nt, new_ne
         integer :: i, j, t, v1, v2, v3, e1, e2, e3
-        integer :: mid1, mid2, mid3  ! Midpoint vertex indices
-        integer, allocatable :: edge_midpoints(:)  ! Maps edge to midpoint vertex
+        integer :: mid1, mid2, mid3 ! Midpoint vertex indices
+        integer, allocatable :: edge_midpoints(:) ! Maps edge to midpoint vertex
         real(dp) :: x1, y1, x2, y2
-        
+
         old_nv = this%n_vertices
         old_nt = this%n_triangles
         old_ne = this%n_edges
-        
+
         ! Calculate new mesh sizes
         ! Each triangle splits into 4, so 4 * old_nt triangles
         ! New vertices: old vertices + midpoint of each edge
         new_nv = old_nv + old_ne
         new_nt = 4 * old_nt
-        new_ne = 2 * old_ne + 3 * old_nt  ! Approximate new edge count
-        
+        new_ne = 2 * old_ne + 3 * old_nt ! Approximate new edge count
+
         ! Allocate arrays for refined mesh
         refined_mesh%n_vertices = new_nv
         refined_mesh%n_triangles = new_nt
@@ -898,85 +898,85 @@ contains
         allocate(refined_mesh%vertices(2, new_nv))
         allocate(refined_mesh%triangles(3, new_nt))
         allocate(edge_midpoints(old_ne))
-        
+
         ! Copy original vertices
         refined_mesh%vertices(:, 1:old_nv) = this%vertices(:, 1:old_nv)
-        
+
         ! Create midpoint vertices for each edge
         do i = 1, old_ne
             v1 = this%edges(1, i)
             v2 = this%edges(2, i)
-            
+
             ! Midpoint coordinates
             x1 = this%vertices(1, v1)
             y1 = this%vertices(2, v1)
             x2 = this%vertices(1, v2)
             y2 = this%vertices(2, v2)
-            
+
             ! New vertex index
             edge_midpoints(i) = old_nv + i
-            
+
             ! Midpoint coordinates
             refined_mesh%vertices(1, edge_midpoints(i)) = 0.5_dp * (x1 + x2)
             refined_mesh%vertices(2, edge_midpoints(i)) = 0.5_dp * (y1 + y2)
         end do
-        
+
         ! Create 4 new triangles for each original triangle
         do t = 1, old_nt
             v1 = this%triangles(1, t)
             v2 = this%triangles(2, t)
             v3 = this%triangles(3, t)
-            
+
             ! Find edges of this triangle
             e1 = find_edge_between_vertices(this, v1, v2)
             e2 = find_edge_between_vertices(this, v2, v3)
             e3 = find_edge_between_vertices(this, v3, v1)
-            
+
             ! Get midpoint vertices
-            mid1 = edge_midpoints(e1)  ! Midpoint of edge v1-v2
-            mid2 = edge_midpoints(e2)  ! Midpoint of edge v2-v3
-            mid3 = edge_midpoints(e3)  ! Midpoint of edge v3-v1
-            
+            mid1 = edge_midpoints(e1) ! Midpoint of edge v1-v2
+            mid2 = edge_midpoints(e2) ! Midpoint of edge v2-v3
+            mid3 = edge_midpoints(e3) ! Midpoint of edge v3-v1
+
             ! Create 4 new triangles
             ! Triangle 1: corner at v1
             refined_mesh%triangles(1, 4*(t-1)+1) = v1
             refined_mesh%triangles(2, 4*(t-1)+1) = mid1
             refined_mesh%triangles(3, 4*(t-1)+1) = mid3
-            
+
             ! Triangle 2: corner at v2
             refined_mesh%triangles(1, 4*(t-1)+2) = v2
             refined_mesh%triangles(2, 4*(t-1)+2) = mid2
             refined_mesh%triangles(3, 4*(t-1)+2) = mid1
-            
+
             ! Triangle 3: corner at v3
             refined_mesh%triangles(1, 4*(t-1)+3) = v3
             refined_mesh%triangles(2, 4*(t-1)+3) = mid3
             refined_mesh%triangles(3, 4*(t-1)+3) = mid2
-            
+
             ! Triangle 4: center triangle
             refined_mesh%triangles(1, 4*(t-1)+4) = mid1
             refined_mesh%triangles(2, 4*(t-1)+4) = mid2
             refined_mesh%triangles(3, 4*(t-1)+4) = mid3
         end do
-        
+
         ! Build connectivity for refined mesh
         call refined_mesh%build_connectivity()
         call refined_mesh%find_boundary()
-        
+
         deallocate(edge_midpoints)
     end subroutine refine_mesh_uniform
-    
+
     ! Adaptive red-green refinement
     subroutine refine_mesh_adaptive(this, refine_markers, refined_mesh)
         class(mesh_2d_t), intent(in) :: this
         logical, intent(in) :: refine_markers(:)
         class(mesh_2d_t), intent(out) :: refined_mesh
         integer :: marked_count, total_count
-        
+
         ! Count marked triangles
         marked_count = count(refine_markers)
         total_count = size(refine_markers)
-        
+
         ! If most triangles are marked, use uniform refinement
         if (marked_count > total_count / 2) then
             call refine_mesh_uniform(this, refined_mesh)
@@ -985,7 +985,7 @@ contains
             call refine_mesh_selective(this, refine_markers, refined_mesh)
         end if
     end subroutine refine_mesh_adaptive
-    
+
     ! Selective refinement (simplified version)
     subroutine refine_mesh_selective(this, refine_markers, refined_mesh)
         class(mesh_2d_t), intent(in) :: this
@@ -995,15 +995,15 @@ contains
         integer :: old_nv, old_nt, t, i
         integer, allocatable :: edge_midpoints(:, :)
         logical, allocatable :: vertex_added(:, :)
-        
+
         old_nv = this%n_vertices
         old_nt = this%n_triangles
         marked_count = count(refine_markers)
-        
+
         ! Simplified: each marked triangle becomes 4, unmarked stay as 1
         new_triangles = old_nt + 3 * marked_count
-        new_vertices = old_nv + 3 * marked_count  ! Approximate
-        
+        new_vertices = old_nv + 3 * marked_count ! Approximate
+
         ! Initialize refined mesh
         refined_mesh%n_vertices = new_vertices
         refined_mesh%n_triangles = new_triangles
@@ -1015,16 +1015,16 @@ contains
         allocate(refined_mesh%triangles(3, new_triangles))
         allocate(edge_midpoints(3, old_nt))
         allocate(vertex_added(3, old_nt))
-        
+
         ! Copy original vertices
         refined_mesh%vertices(:, 1:old_nv) = this%vertices(:, 1:old_nv)
-        
+
         ! Track edge midpoints and new triangles
         edge_midpoints = 0
         vertex_added = .false.
         new_vertices = old_nv
         new_triangles = 0
-        
+
         do t = 1, old_nt
             if (refine_markers(t)) then
                 ! Refine this triangle (create edge midpoints and 4 triangles)
@@ -1036,21 +1036,21 @@ contains
                 refined_mesh%triangles(:, new_triangles) = this%triangles(:, t)
             end if
         end do
-        
+
         ! Update final counts
         refined_mesh%n_vertices = new_vertices
         refined_mesh%n_triangles = new_triangles
-        
+
         ! Build connectivity
         call refined_mesh%build_connectivity()
         call refined_mesh%find_boundary()
-        
+
         deallocate(edge_midpoints, vertex_added)
     end subroutine refine_mesh_selective
-    
+
     ! Helper to add refined triangle in selective refinement
     subroutine add_refined_triangle_selective(original_mesh, refined_mesh, tri_idx, &
-        edge_midpoints, vertex_added, new_vertices, new_triangles)
+            edge_midpoints, vertex_added, new_vertices, new_triangles)
         class(mesh_2d_t), intent(in) :: original_mesh
         class(mesh_2d_t), intent(inout) :: refined_mesh
         integer, intent(in) :: tri_idx
@@ -1058,11 +1058,11 @@ contains
         logical, intent(inout) :: vertex_added(:, :)
         integer, intent(inout) :: new_vertices, new_triangles
         integer :: v1, v2, v3, mid1, mid2, mid3
-        
+
         v1 = original_mesh%triangles(1, tri_idx)
         v2 = original_mesh%triangles(2, tri_idx)
         v3 = original_mesh%triangles(3, tri_idx)
-        
+
         ! Add edge midpoints if not already added
         if (.not. vertex_added(1, tri_idx)) then
             new_vertices = new_vertices + 1
@@ -1070,68 +1070,68 @@ contains
             edge_midpoints(1, tri_idx) = mid1
             vertex_added(1, tri_idx) = .true.
             refined_mesh%vertices(1, mid1) = 0.5_dp * (original_mesh%vertices(1, v1) + &
-                                                      original_mesh%vertices(1, v2))
+                original_mesh%vertices(1, v2))
             refined_mesh%vertices(2, mid1) = 0.5_dp * (original_mesh%vertices(2, v1) + &
-                                                      original_mesh%vertices(2, v2))
+                original_mesh%vertices(2, v2))
         else
             mid1 = edge_midpoints(1, tri_idx)
         end if
-        
+
         if (.not. vertex_added(2, tri_idx)) then
             new_vertices = new_vertices + 1
             mid2 = new_vertices
             edge_midpoints(2, tri_idx) = mid2
             vertex_added(2, tri_idx) = .true.
             refined_mesh%vertices(1, mid2) = 0.5_dp * (original_mesh%vertices(1, v2) + &
-                                                      original_mesh%vertices(1, v3))
+                original_mesh%vertices(1, v3))
             refined_mesh%vertices(2, mid2) = 0.5_dp * (original_mesh%vertices(2, v2) + &
-                                                      original_mesh%vertices(2, v3))
+                original_mesh%vertices(2, v3))
         else
             mid2 = edge_midpoints(2, tri_idx)
         end if
-        
+
         if (.not. vertex_added(3, tri_idx)) then
             new_vertices = new_vertices + 1
             mid3 = new_vertices
             edge_midpoints(3, tri_idx) = mid3
             vertex_added(3, tri_idx) = .true.
             refined_mesh%vertices(1, mid3) = 0.5_dp * (original_mesh%vertices(1, v3) + &
-                                                      original_mesh%vertices(1, v1))
+                original_mesh%vertices(1, v1))
             refined_mesh%vertices(2, mid3) = 0.5_dp * (original_mesh%vertices(2, v3) + &
-                                                      original_mesh%vertices(2, v1))
+                original_mesh%vertices(2, v1))
         else
             mid3 = edge_midpoints(3, tri_idx)
         end if
-        
+
         ! Create 4 new triangles
         new_triangles = new_triangles + 1
         refined_mesh%triangles(1, new_triangles) = v1
         refined_mesh%triangles(2, new_triangles) = mid1
         refined_mesh%triangles(3, new_triangles) = mid3
-        
+
         new_triangles = new_triangles + 1
         refined_mesh%triangles(1, new_triangles) = mid1
         refined_mesh%triangles(2, new_triangles) = v2
         refined_mesh%triangles(3, new_triangles) = mid2
-        
+
         new_triangles = new_triangles + 1
         refined_mesh%triangles(1, new_triangles) = mid3
         refined_mesh%triangles(2, new_triangles) = mid2
         refined_mesh%triangles(3, new_triangles) = v3
-        
+
         new_triangles = new_triangles + 1
         refined_mesh%triangles(1, new_triangles) = mid1
         refined_mesh%triangles(2, new_triangles) = mid2
         refined_mesh%triangles(3, new_triangles) = mid3
     end subroutine add_refined_triangle_selective
-    
+
     ! Helper function to find edge between two vertices
     function find_edge_between_vertices(mesh, v1, v2) result(edge_id)
         type(mesh_2d_t), intent(in) :: mesh
         integer, intent(in) :: v1, v2
         integer :: edge_id
         integer :: i
-        
+
         edge_id = 0
         do i = 1, mesh%n_edges
             if ((mesh%edges(1, i) == v1 .and. mesh%edges(2, i) == v2) .or. &
@@ -1140,15 +1140,15 @@ contains
                 return
             end if
         end do
-        
+
         ! Edge not found - this indicates a corrupted mesh topology
         write(*,*) "Error: Edge between vertices", v1, "and", v2, "not found"
         write(*,*) "This indicates a corrupted mesh topology"
         error stop "Fatal error in find_edge_between_vertices"
     end function find_edge_between_vertices
-    
+
     ! Quadrilateral mesh creation and operations
-    
+
     ! Create structured quadrilateral mesh
     subroutine create_structured_quads(this, nx, ny, x0, x1, y0, y1)
         class(mesh_2d_t), intent(inout) :: this
@@ -1156,7 +1156,7 @@ contains
         real(dp), intent(in) :: x0, x1, y0, y1
         integer :: i, j, iv, iq
         real(dp) :: dx, dy
-        
+
         ! Initialize mesh
         this%n_vertices = (nx + 1) * (ny + 1)
         this%n_quads = nx * ny
@@ -1164,29 +1164,29 @@ contains
         this%has_quads = .true.
         this%has_triangles = .false.
         this%has_mixed_elements = .false.
-        
+
         ! Allocate arrays
         allocate(this%vertices(2, this%n_vertices))
         allocate(this%quads(4, this%n_quads))
         allocate(this%is_boundary_vertex(this%n_vertices))
-        
+
         ! Create vertices
         dx = (x1 - x0) / real(nx, dp)
         dy = (y1 - y0) / real(ny, dp)
-        
+
         iv = 0
         do j = 0, ny
             do i = 0, nx
                 iv = iv + 1
                 this%vertices(1, iv) = x0 + real(i, dp) * dx
                 this%vertices(2, iv) = y0 + real(j, dp) * dy
-                
+
                 ! Mark boundary vertices
                 this%is_boundary_vertex(iv) = (i == 0 .or. i == nx .or. &
-                                             j == 0 .or. j == ny)
+                    j == 0 .or. j == ny)
             end do
         end do
-        
+
         ! Create quadrilaterals
         iq = 0
         do j = 0, ny - 1
@@ -1199,61 +1199,61 @@ contains
                 this%quads(4, iq) = (j + 1) * (nx + 1) + i + 1
             end do
         end do
-        
+
         ! Build connectivity (edges and adjacency)
         call this%build_connectivity()
     end subroutine create_structured_quads
-    
+
     ! Get edges of a quadrilateral
     subroutine get_quad_edges(this, quad_id, edge_ids)
         class(mesh_2d_t), intent(in) :: this
         integer, intent(in) :: quad_id
         integer, intent(out) :: edge_ids(4)
         integer :: i, v1, v2, edge_found
-        
+
         do i = 1, 4
             v1 = this%quads(i, quad_id)
             v2 = this%quads(mod(i, 4) + 1, quad_id)
-            
+
             ! Find edge between v1 and v2
             call find_edge(this, v1, v2, edge_found)
             edge_ids(i) = edge_found
         end do
     end subroutine get_quad_edges
-    
+
     ! Get vertices of a quadrilateral
     subroutine get_quad_vertices(this, quad_id, vertex_coords)
         class(mesh_2d_t), intent(in) :: this
         integer, intent(in) :: quad_id
         real(dp), intent(out) :: vertex_coords(2, 4)
         integer :: i, v
-        
+
         do i = 1, 4
             v = this%quads(i, quad_id)
             vertex_coords(:, i) = this%vertices(:, v)
         end do
     end subroutine get_quad_vertices
-    
-        ! Build connectivity for quadrilateral elements (edges and quad mapping)
+
+    ! Build connectivity for quadrilateral elements (edges and quad mapping)
     subroutine build_quad_connectivity(this)
         class(mesh_2d_t), intent(inout) :: this
         integer :: i, j, v1, v2, edge_count
         integer, allocatable :: edge_list(:, :)
         logical, allocatable :: edge_exists(:)
-        
+
         if (.not. this%has_quads) return
-        
+
         ! Count and create edges for quadrilaterals
         edge_count = 0
         allocate(edge_list(2, 4 * this%n_quads))
-        
+
         ! Collect all edges from quads
         do i = 1, this%n_quads
             do j = 1, 4
                 edge_count = edge_count + 1
                 edge_list(1, edge_count) = this%quads(j, i)
                 edge_list(2, edge_count) = this%quads(mod(j, 4) + 1, i)
-                
+
                 ! Ensure consistent edge orientation (smaller vertex first)
                 if (edge_list(1, edge_count) > edge_list(2, edge_count)) then
                     v1 = edge_list(1, edge_count)
@@ -1262,58 +1262,58 @@ contains
                 end if
             end do
         end do
-        
+
         ! Remove duplicate edges
         call remove_duplicate_edges(edge_list, edge_count, this%edges, this%n_edges)
-        
+
         ! Allocate connectivity arrays
         if (allocated(this%edge_to_quads)) deallocate(this%edge_to_quads)
         allocate(this%edge_to_quads(2, this%n_edges))
         this%edge_to_quads = 0
-        
+
         ! Build edge-to-quad connectivity
         call build_edge_quad_mapping(this)
-        
+
         deallocate(edge_list)
     end subroutine build_quad_connectivity
-    
+
     ! Build connectivity for mixed triangle-quad meshes
     subroutine build_mixed_connectivity(this)
         class(mesh_2d_t), intent(inout) :: this
-        
+
         this%has_mixed_elements = (this%has_triangles .and. this%has_quads)
         if (.not. this%has_mixed_elements) return
-        
+
         call merge_triangle_quad_connectivity(this)
     end subroutine build_mixed_connectivity
-    
+
     ! Helper procedures for quadrilateral support
-    
+
     subroutine find_edge(mesh, v1, v2, edge_id)
         type(mesh_2d_t), intent(in) :: mesh
         integer, intent(in) :: v1, v2
         integer, intent(out) :: edge_id
         integer :: i, va, vb
-        
+
         edge_id = 0
-        
+
         ! Ensure consistent vertex ordering
         va = min(v1, v2)
         vb = max(v1, v2)
-        
+
         do i = 1, mesh%n_edges
             if ((mesh%edges(1, i) == va .and. mesh%edges(2, i) == vb)) then
                 edge_id = i
                 return
             end if
         end do
-        
+
         ! Edge not found - this indicates a corrupted mesh topology
         write(*,*) "Error: Edge between vertices", v1, "and", v2, "not found"
         write(*,*) "This indicates a corrupted mesh topology"
         error stop "Fatal error in find_edge"
     end subroutine find_edge
-    
+
     subroutine remove_duplicate_edges(edge_list, edge_count, unique_edges, n_unique)
         integer, intent(in) :: edge_count
         integer, intent(in) :: edge_list(2, edge_count)
@@ -1321,10 +1321,10 @@ contains
         integer, intent(out) :: n_unique
         logical, allocatable :: is_duplicate(:)
         integer :: i, j, edge_counter
-        
+
         allocate(is_duplicate(edge_count))
         is_duplicate = .false.
-        
+
         ! Mark duplicates
         do i = 1, edge_count
             if (is_duplicate(i)) cycle
@@ -1335,11 +1335,11 @@ contains
                 end if
             end do
         end do
-        
+
         ! Count unique edges
         n_unique = count(.not. is_duplicate)
         allocate(unique_edges(2, n_unique))
-        
+
         edge_counter = 0
         do i = 1, edge_count
             if (.not. is_duplicate(i)) then
@@ -1347,20 +1347,20 @@ contains
                 unique_edges(:, edge_counter) = edge_list(:, i)
             end if
         end do
-        
+
         deallocate(is_duplicate)
     end subroutine remove_duplicate_edges
-    
+
     subroutine build_edge_quad_mapping(mesh)
         type(mesh_2d_t), intent(inout) :: mesh
         integer :: i, j, edge_id
-        
+
         ! For each quad, find its edges and update connectivity
         do i = 1, mesh%n_quads
             do j = 1, 4
                 call find_edge(mesh, mesh%quads(j, i), &
-                             mesh%quads(mod(j, 4) + 1, i), edge_id)
-                
+                    mesh%quads(mod(j, 4) + 1, i), edge_id)
+
                 if (edge_id > 0) then
                     if (mesh%edge_to_quads(1, edge_id) == 0) then
                         mesh%edge_to_quads(1, edge_id) = i
@@ -1371,27 +1371,27 @@ contains
             end do
         end do
     end subroutine build_edge_quad_mapping
-    
+
     subroutine merge_triangle_quad_connectivity(mesh)
         type(mesh_2d_t), intent(inout) :: mesh
-        
+
         integer :: total_edges, triangle_edges, quad_edges
         integer, allocatable :: all_edges(:,:), edge_counts(:)
         integer :: i, j, edge_idx, v1, v2
         logical, allocatable :: is_duplicate(:)
-        
+
         ! Count edges from triangles and quads
         triangle_edges = 3 * mesh%n_triangles
         quad_edges = 4 * mesh%n_quads
         total_edges = triangle_edges + quad_edges
-        
+
         ! Collect all edges
         allocate(all_edges(2, total_edges))
         allocate(edge_counts(total_edges))
         edge_counts = 1
-        
+
         edge_idx = 0
-        
+
         ! Add triangle edges
         do i = 1, mesh%n_triangles
             do j = 1, 3
@@ -1403,7 +1403,7 @@ contains
                 all_edges(2, edge_idx) = max(v1, v2)
             end do
         end do
-        
+
         ! Add quad edges
         do i = 1, mesh%n_quads
             do j = 1, 4
@@ -1415,11 +1415,11 @@ contains
                 all_edges(2, edge_idx) = max(v1, v2)
             end do
         end do
-        
+
         ! Find and count duplicate edges
         allocate(is_duplicate(total_edges))
         is_duplicate = .false.
-        
+
         do i = 1, total_edges
             if (is_duplicate(i)) cycle
             do j = i + 1, total_edges
@@ -1430,12 +1430,12 @@ contains
                 end if
             end do
         end do
-        
+
         ! Build unified edge list
         mesh%n_edges = count(.not. is_duplicate)
         if (allocated(mesh%edges)) deallocate(mesh%edges)
         allocate(mesh%edges(2, mesh%n_edges))
-        
+
         j = 0
         do i = 1, total_edges
             if (.not. is_duplicate(i)) then
@@ -1443,7 +1443,7 @@ contains
                 mesh%edges(:, j) = all_edges(:, i)
             end if
         end do
-        
+
         ! Initialize connectivity arrays for mixed elements
         if (allocated(mesh%edge_to_triangles)) deallocate(mesh%edge_to_triangles)
         if (allocated(mesh%edge_to_quads)) deallocate(mesh%edge_to_quads)
@@ -1451,7 +1451,7 @@ contains
         allocate(mesh%edge_to_quads(2, mesh%n_edges))
         mesh%edge_to_triangles = 0
         mesh%edge_to_quads = 0
-        
+
         ! Build triangle-edge connectivity
         do i = 1, mesh%n_triangles
             do j = 1, 3
@@ -1467,7 +1467,7 @@ contains
                 end if
             end do
         end do
-        
+
         ! Build quad-edge connectivity
         do i = 1, mesh%n_quads
             do j = 1, 4
@@ -1483,16 +1483,16 @@ contains
                 end if
             end do
         end do
-        
+
         deallocate(all_edges, edge_counts, is_duplicate)
     end subroutine merge_triangle_quad_connectivity
-    
+
     subroutine find_edge_index(mesh, v1, v2, edge_idx)
         type(mesh_2d_t), intent(in) :: mesh
         integer, intent(in) :: v1, v2
         integer, intent(out) :: edge_idx
         integer :: i
-        
+
         edge_idx = 0
         do i = 1, mesh%n_edges
             if (mesh%edges(1, i) == v1 .and. mesh%edges(2, i) == v2) then

--- a/src/mesh/triangle_io.f90
+++ b/src/mesh/triangle_io.f90
@@ -75,7 +75,7 @@ contains
         end if
 
         open(newunit=unit_num, file=filename, status="old", action="read",    &
-             iostat=stat)
+            iostat=stat)
         if (stat /= 0) return
 
         ! Skip comment lines starting with #
@@ -97,7 +97,7 @@ contains
         end if
 
         if (dim /= 2) then
-            stat = 2  ! Only 2D supported
+            stat = 2 ! Only 2D supported
             close(unit_num)
             return
         end if
@@ -158,7 +158,7 @@ contains
         end if
 
         open(newunit=unit_num, file=filename, status="old", action="read",    &
-             iostat=stat)
+            iostat=stat)
         if (stat /= 0) return
 
         ! Skip comment lines
@@ -180,7 +180,7 @@ contains
         end if
 
         if (nodes_per_tri /= 3) then
-            stat = 2  ! Only linear triangles supported
+            stat = 2 ! Only linear triangles supported
             close(unit_num)
             return
         end if
@@ -214,7 +214,7 @@ contains
     end subroutine read_triangle_ele_file
 
     subroutine read_triangle_poly_file(filename, vertices, segments,          &
-                                       n_vertices, n_segments, stat)
+            n_vertices, n_segments, stat)
         !> Read PSLG from Triangle .poly file format.
         !
         !  Arguments:
@@ -249,7 +249,7 @@ contains
         end if
 
         open(newunit=unit_num, file=filename, status="old", action="read",    &
-             iostat=stat)
+            iostat=stat)
         if (stat /= 0) return
 
         ! Skip comment lines and read vertex header
@@ -336,8 +336,8 @@ contains
     end subroutine read_triangle_poly_file
 
     subroutine write_triangle_poly_file(filename, vertices, segments,         &
-                                        n_vertices, n_segments, stat,        &
-                                        hole_points)
+            n_vertices, n_segments, stat,        &
+            hole_points)
         !> Write PSLG to Triangle .poly file format.
         !
         !  Arguments:
@@ -359,7 +359,7 @@ contains
         integer :: unit_num, i, nholes
 
         open(newunit=unit_num, file=filename, status="replace", action="write",&
-             iostat=stat)
+            iostat=stat)
         if (stat /= 0) return
 
         ! Write vertex header: n_vertices dimension n_attributes n_bm
@@ -405,7 +405,7 @@ contains
     end subroutine write_triangle_poly_file
 
     subroutine read_triangle_mesh(basename, vertices, triangles,              &
-                                  n_vertices, n_triangles, stat)
+            n_vertices, n_triangles, stat)
         !> Read complete mesh from Triangle output files (.node and .ele).
         !
         !  Triangle outputs meshes with a numeric suffix (e.g., .1.node, .1.ele).
@@ -464,7 +464,7 @@ contains
         ! Download Triangle source from netlib
         write(*, '(A)') "   Downloading Triangle from netlib.org..."
         cmd = "wget -q http://www.netlib.org/voronoi/triangle.zip "           &
-              // "-O /tmp/triangle_download.zip 2>/dev/null"
+            // "-O /tmp/triangle_download.zip 2>/dev/null"
         call execute_command_line(trim(cmd), wait=.true., exitstat=stat)
         if (stat /= 0) then
             write(*, '(A)') "   Warning: Failed to download Triangle"
@@ -482,7 +482,7 @@ contains
         ! Compile (using gnu89 for K&R C compatibility)
         write(*, '(A)') "   Compiling Triangle..."
         cmd = "cd /tmp && gcc -std=gnu89 -O2 -DLINUX -o " // trim(triangle_path) &
-              // " triangle.c -lm 2>/dev/null"
+            // " triangle.c -lm 2>/dev/null"
         call execute_command_line(trim(cmd), wait=.true., exitstat=stat)
         if (stat /= 0) then
             write(*, '(A)') "   Warning: Failed to compile Triangle"

--- a/src/quadrature/gauss_quadrature_2d.f90
+++ b/src/quadrature/gauss_quadrature_2d.f90
@@ -21,7 +21,7 @@ contains
     subroutine init(this, order)
         class(gauss_quadrature_triangle_t), intent(out) :: this
         integer, intent(in) :: order
-        
+
         select case(order)
         case(1)
             call init_order_1(this)
@@ -46,7 +46,7 @@ contains
 
     subroutine destroy(this)
         class(gauss_quadrature_triangle_t), intent(inout) :: this
-        
+
         if (allocated(this%xi)) deallocate(this%xi)
         if (allocated(this%eta)) deallocate(this%eta)
         if (allocated(this%weights)) deallocate(this%weights)
@@ -58,7 +58,7 @@ contains
         integer, intent(in) :: degree
         type(gauss_quadrature_triangle_t) :: quad
         integer :: order
-        
+
         ! Map polynomial degree to quadrature order
         ! order p integrates polynomials of degree 2p-1 exactly
         if (degree <= 1) then
@@ -76,29 +76,29 @@ contains
         else
             order = 7
         end if
-        
+
         call quad%init(order)
     end function
 
     ! Order 1: degree 1 exact, 1 point (centroid)
     subroutine init_order_1(this)
         type(gauss_quadrature_triangle_t), intent(out) :: this
-        
+
         this%n_points = 1
         allocate(this%xi(1), this%eta(1), this%weights(1))
-        
+
         this%xi(1) = 1.0_dp/3.0_dp
         this%eta(1) = 1.0_dp/3.0_dp
-        this%weights(1) = 0.5_dp  ! Area of reference triangle
+        this%weights(1) = 0.5_dp ! Area of reference triangle
     end subroutine
 
     ! Order 2: degree 2 exact, 3 points (edge midpoints)
     subroutine init_order_2(this)
         type(gauss_quadrature_triangle_t), intent(out) :: this
-        
+
         this%n_points = 3
         allocate(this%xi(3), this%eta(3), this%weights(3))
-        
+
         this%xi = [0.5_dp, 0.0_dp, 0.5_dp]
         this%eta = [0.0_dp, 0.5_dp, 0.5_dp]
         this%weights = [1.0_dp/6.0_dp, 1.0_dp/6.0_dp, 1.0_dp/6.0_dp]
@@ -107,24 +107,24 @@ contains
     ! Order 3: degree 3 exact, 4 points
     subroutine init_order_3(this)
         type(gauss_quadrature_triangle_t), intent(out) :: this
-        
+
         this%n_points = 4
         allocate(this%xi(4), this%eta(4), this%weights(4))
-        
+
         ! Centroid point
         this%xi(1) = 1.0_dp/3.0_dp
         this%eta(1) = 1.0_dp/3.0_dp
         this%weights(1) = -27.0_dp/96.0_dp
-        
+
         ! Three points on edges
         this%xi(2) = 0.6_dp
         this%eta(2) = 0.2_dp
         this%weights(2) = 25.0_dp/96.0_dp
-        
+
         this%xi(3) = 0.2_dp
         this%eta(3) = 0.6_dp
         this%weights(3) = 25.0_dp/96.0_dp
-        
+
         this%xi(4) = 0.2_dp
         this%eta(4) = 0.2_dp
         this%weights(4) = 25.0_dp/96.0_dp
@@ -137,32 +137,32 @@ contains
         real(dp), parameter :: b = 0.091576213509771_dp
         real(dp), parameter :: w1 = 0.111690794839005_dp
         real(dp), parameter :: w2 = 0.054975871827661_dp
-        
+
         this%n_points = 6
         allocate(this%xi(6), this%eta(6), this%weights(6))
-        
+
         ! Three points near vertices
         this%xi(1) = a
         this%eta(1) = 1.0_dp - 2.0_dp*a
         this%weights(1) = w1
-        
+
         this%xi(2) = a
         this%eta(2) = a
         this%weights(2) = w1
-        
+
         this%xi(3) = 1.0_dp - 2.0_dp*a
         this%eta(3) = a
         this%weights(3) = w1
-        
+
         ! Three points near edge midpoints
         this%xi(4) = b
         this%eta(4) = 1.0_dp - 2.0_dp*b
         this%weights(4) = w2
-        
+
         this%xi(5) = b
         this%eta(5) = b
         this%weights(5) = w2
-        
+
         this%xi(6) = 1.0_dp - 2.0_dp*b
         this%eta(6) = b
         this%weights(6) = w2
@@ -178,37 +178,37 @@ contains
         real(dp), parameter :: w0 = 0.225000000000000_dp
         real(dp), parameter :: w1 = 0.125939180544827_dp
         real(dp), parameter :: w2 = 0.132394152788506_dp
-        
+
         this%n_points = 7
         allocate(this%xi(7), this%eta(7), this%weights(7))
-        
+
         ! Centroid
         this%xi(1) = 1.0_dp/3.0_dp
         this%eta(1) = 1.0_dp/3.0_dp
         this%weights(1) = w0 * 0.5_dp
-        
+
         ! First group: three points
         this%xi(2) = a2
         this%eta(2) = a1
         this%weights(2) = w1 * 0.5_dp
-        
+
         this%xi(3) = a1
         this%eta(3) = a2
         this%weights(3) = w1 * 0.5_dp
-        
+
         this%xi(4) = a1
         this%eta(4) = a1
         this%weights(4) = w1 * 0.5_dp
-        
+
         ! Second group: three points
         this%xi(5) = b2
         this%eta(5) = b1
         this%weights(5) = w2 * 0.5_dp
-        
+
         this%xi(6) = b1
         this%eta(6) = b2
         this%weights(6) = w2 * 0.5_dp
-        
+
         this%xi(7) = b1
         this%eta(7) = b1
         this%weights(7) = w2 * 0.5_dp
@@ -224,57 +224,57 @@ contains
         real(dp), parameter :: w1 = 0.050844906370207_dp
         real(dp), parameter :: w2 = 0.116786275726379_dp
         real(dp), parameter :: w3 = 0.082851075618374_dp
-        
+
         this%n_points = 12
         allocate(this%xi(12), this%eta(12), this%weights(12))
-        
+
         ! First group: 3 points
         this%xi(1) = a
         this%eta(1) = a
         this%weights(1) = w1 * 0.5_dp
-        
+
         this%xi(2) = 1.0_dp - 2.0_dp*a
         this%eta(2) = a
         this%weights(2) = w1 * 0.5_dp
-        
+
         this%xi(3) = a
         this%eta(3) = 1.0_dp - 2.0_dp*a
         this%weights(3) = w1 * 0.5_dp
-        
+
         ! Second group: 3 points
         this%xi(4) = b
         this%eta(4) = b
         this%weights(4) = w2 * 0.5_dp
-        
+
         this%xi(5) = 1.0_dp - 2.0_dp*b
         this%eta(5) = b
         this%weights(5) = w2 * 0.5_dp
-        
+
         this%xi(6) = b
         this%eta(6) = 1.0_dp - 2.0_dp*b
         this%weights(6) = w2 * 0.5_dp
-        
+
         ! Third group: 6 points
         this%xi(7) = c
         this%eta(7) = d
         this%weights(7) = w3 * 0.5_dp
-        
+
         this%xi(8) = d
         this%eta(8) = c
         this%weights(8) = w3 * 0.5_dp
-        
+
         this%xi(9) = 1.0_dp - c - d
         this%eta(9) = c
         this%weights(9) = w3 * 0.5_dp
-        
+
         this%xi(10) = 1.0_dp - c - d
         this%eta(10) = d
         this%weights(10) = w3 * 0.5_dp
-        
+
         this%xi(11) = c
         this%eta(11) = 1.0_dp - c - d
         this%weights(11) = w3 * 0.5_dp
-        
+
         this%xi(12) = d
         this%eta(12) = 1.0_dp - c - d
         this%weights(12) = w3 * 0.5_dp
@@ -292,62 +292,62 @@ contains
         real(dp), parameter :: w1 = 0.0533472356089_dp
         real(dp), parameter :: w2 = 0.0771137608903_dp
         real(dp), parameter :: w3 = 0.1756152574332_dp
-        
+
         this%n_points = 13
         allocate(this%xi(13), this%eta(13), this%weights(13))
-        
+
         ! Centroid
         this%xi(1) = 1.0_dp/3.0_dp
         this%eta(1) = 1.0_dp/3.0_dp
         this%weights(1) = w0 * 0.5_dp
-        
+
         ! First group: 3 points
         this%xi(2) = a
         this%eta(2) = a
         this%weights(2) = w1 * 0.5_dp
-        
+
         this%xi(3) = 1.0_dp - 2.0_dp*a
         this%eta(3) = a
         this%weights(3) = w1 * 0.5_dp
-        
+
         this%xi(4) = a
         this%eta(4) = 1.0_dp - 2.0_dp*a
         this%weights(4) = w1 * 0.5_dp
-        
+
         ! Second group: 3 points
         this%xi(5) = b
         this%eta(5) = b
         this%weights(5) = w2 * 0.5_dp
-        
+
         this%xi(6) = 1.0_dp - 2.0_dp*b
         this%eta(6) = b
         this%weights(6) = w2 * 0.5_dp
-        
+
         this%xi(7) = b
         this%eta(7) = 1.0_dp - 2.0_dp*b
         this%weights(7) = w2 * 0.5_dp
-        
+
         ! Third group: 6 points
         this%xi(8) = c
         this%eta(8) = d
         this%weights(8) = w3 * 0.5_dp
-        
+
         this%xi(9) = d
         this%eta(9) = c
         this%weights(9) = w3 * 0.5_dp
-        
+
         this%xi(10) = 1.0_dp - c - d
         this%eta(10) = c
         this%weights(10) = w3 * 0.5_dp
-        
+
         this%xi(11) = 1.0_dp - c - d
         this%eta(11) = d
         this%weights(11) = w3 * 0.5_dp
-        
+
         this%xi(12) = c
         this%eta(12) = 1.0_dp - c - d
         this%weights(12) = w3 * 0.5_dp
-        
+
         this%xi(13) = d
         this%eta(13) = 1.0_dp - c - d
         this%weights(13) = w3 * 0.5_dp

--- a/src/solvers/advanced_solvers.f90
+++ b/src/solvers/advanced_solvers.f90
@@ -1,10 +1,10 @@
 module fortfem_advanced_solvers
     use fortfem_kinds, only: dp
     use fortfem_sparse_matrix, only: sparse_matrix_t, sparse_from_dense, &
-                                     sparse_to_csc, spmv
+        sparse_to_csc, spmv
     use fortfem_krylov_solvers, only: gmres_impl, bicgstab_impl
     use fortfem_umfpack_interface, only: umfpack_solve_csc, &
-                                         umfpack_available
+        umfpack_available
     implicit none
     private
 
@@ -37,8 +37,8 @@ module fortfem_advanced_solvers
         logical :: parallel = .false.
         integer :: num_threads = 1
         integer :: verbosity = 0
-        real(dp) :: drop_tolerance = 1.0e-4_dp  ! For ILU
-        integer :: fill_level = 0  ! For ILU
+        real(dp) :: drop_tolerance = 1.0e-4_dp ! For ILU
+        integer :: fill_level = 0 ! For ILU
     end type solver_options_t
 
     ! Solver statistics type
@@ -47,7 +47,7 @@ module fortfem_advanced_solvers
         integer :: iterations = 0
         real(dp) :: final_residual = 0.0_dp
         real(dp) :: solve_time = 0.0_dp
-        integer :: memory_usage = 0  ! In bytes
+        integer :: memory_usage = 0 ! In bytes
         character(len=32) :: method_used = ""
         integer :: restarts = 0
         real(dp) :: parallel_efficiency = 0.0_dp
@@ -57,9 +57,9 @@ module fortfem_advanced_solvers
     ! Preconditioner type
     type :: preconditioner_t
         character(len=32) :: type = "none"
-        real(dp), allocatable :: diagonal(:)  ! For Jacobi
-        real(dp), allocatable :: L(:, :), U(:, :)  ! For ILU
-        integer, allocatable :: pivot(:)  ! For ILU
+        real(dp), allocatable :: diagonal(:) ! For Jacobi
+        real(dp), allocatable :: L(:, :), U(:, :) ! For ILU
+        integer, allocatable :: pivot(:) ! For ILU
     end type preconditioner_t
 
     abstract interface
@@ -157,7 +157,7 @@ contains
 
         if (trim(local_opts%preconditioner) /= "none") then
             call build_sparse_preconditioner(A_sparse, precond, &
-                                             local_opts%preconditioner, local_opts)
+                local_opts%preconditioner, local_opts)
         else
             precond%type = "none"
         end if
@@ -169,18 +169,18 @@ contains
             call cg_solve_sparse_impl(A_sparse, b, x, local_opts, stats)
         case ("pcg")
             call pcg_solve_sparse_impl(A_sparse, b, x, local_opts, stats, &
-                                       precond)
+                precond)
         case default
             local_opts%method = "pcg"
             call pcg_solve_sparse_impl(A_sparse, b, x, local_opts, stats, &
-                                       precond)
+                precond)
         end select
 
         call cpu_time(end_time)
 
         stats%solve_time = end_time - start_time
         stats%memory_usage = estimate_sparse_memory_usage(A_sparse, &
-                                                          trim(stats%method_used))
+            trim(stats%method_used))
     end subroutine solve_sparse
 
     subroutine cg_solve_sparse_impl(A_sparse, b, x, opts, stats)
@@ -212,7 +212,7 @@ contains
         type(preconditioner_t), intent(in) :: precond
 
         call pcg_solve_operator(sparse_matvec, sparse_apply_precond, b, x, &
-                                opts, stats)
+            opts, stats)
 
     contains
 
@@ -267,12 +267,12 @@ contains
         allocate (r(n), p(n), Ap(n), Ax(n))
 
         call initialize_cg_state(matvec, b, x, r, p, Ap, Ax, rr_old, &
-                                 initial_norm, residual_norm)
+            initial_norm, residual_norm)
         tolerance = compute_solver_tolerance(initial_norm, opts)
         stats%converged = .false.
         stats%iterations = 0
         call cg_iteration_loop(matvec, opts, tolerance, r, p, Ap, x, rr_old, &
-                               residual_norm, stats)
+            residual_norm, stats)
         call finalize_solver_status(stats, residual_norm, tolerance)
         stats%method_used = "cg"
 
@@ -280,7 +280,7 @@ contains
     end subroutine cg_solve_operator
 
     subroutine initialize_cg_state(matvec, b, x, r, p, Ap, Ax, rr_old, &
-                                   initial_norm, residual_norm)
+            initial_norm, residual_norm)
         procedure(matvec_proc) :: matvec
         real(dp), intent(in) :: b(:)
         real(dp), intent(inout) :: x(:)
@@ -296,7 +296,7 @@ contains
     end subroutine initialize_cg_state
 
     subroutine cg_iteration_loop(matvec, opts, tolerance, r, p, Ap, x, &
-                                 rr_old, residual_norm, stats)
+            rr_old, residual_norm, stats)
         procedure(matvec_proc) :: matvec
         type(solver_options_t), intent(in) :: opts
         real(dp), intent(in) :: tolerance
@@ -354,7 +354,7 @@ contains
         call build_preconditioner(A, precond, opts%preconditioner, opts)
 
         call pcg_solve_operator(dense_matvec, dense_apply_precond, b, x, &
-                                opts, stats)
+            opts, stats)
 
     contains
 
@@ -390,12 +390,12 @@ contains
         allocate (r(n), z(n), p(n), Ap(n), Ax(n))
 
         call initialize_pcg_state(matvec, apply_precond, b, x, r, z, p, Ap, &
-                                  Ax, rz_old, initial_norm, residual_norm)
+            Ax, rz_old, initial_norm, residual_norm)
         tolerance = compute_solver_tolerance(initial_norm, opts)
         stats%converged = .false.
         stats%iterations = 0
         call pcg_iteration_loop(matvec, apply_precond, opts, tolerance, r, z, &
-                                p, Ap, x, rz_old, residual_norm, stats)
+            p, Ap, x, rz_old, residual_norm, stats)
         call finalize_solver_status(stats, residual_norm, tolerance)
         stats%method_used = "pcg"
 
@@ -403,7 +403,7 @@ contains
     end subroutine pcg_solve_operator
 
     subroutine initialize_pcg_state(matvec, apply_precond, b, x, r, z, p, Ap, &
-                                    Ax, rz_old, initial_norm, residual_norm)
+            Ax, rz_old, initial_norm, residual_norm)
         procedure(matvec_proc) :: matvec
         procedure(precond_proc) :: apply_precond
         real(dp), intent(in) :: b(:)
@@ -424,7 +424,7 @@ contains
     end subroutine initialize_pcg_state
 
     subroutine pcg_iteration_loop(matvec, apply_precond, opts, tolerance, r, &
-                                  z, p, Ap, x, rz_old, residual_norm, stats)
+            z, p, Ap, x, rz_old, residual_norm, stats)
         procedure(matvec_proc) :: matvec
         procedure(precond_proc) :: apply_precond
         type(solver_options_t), intent(in) :: opts
@@ -485,16 +485,16 @@ contains
         if (use_precond) then
             call build_preconditioner(A, precond, opts%preconditioner, opts)
             call bicgstab_impl(A, b, x, precond%diagonal, precond%L, precond%U, &
-                               use_precond, opts%tolerance, opts%max_iterations, &
-                               opts%tolerance_type, opts%verbosity, stats%converged, &
-                               stats%iterations, stats%final_residual)
+                use_precond, opts%tolerance, opts%max_iterations, &
+                opts%tolerance_type, opts%verbosity, stats%converged, &
+                stats%iterations, stats%final_residual)
         else
             call bicgstab_impl(A, b, x, use_precond=.false., tol=opts%tolerance, &
-                               max_iter=opts%max_iterations, &
-                               tol_type=opts%tolerance_type, &
-                               verbosity=opts%verbosity, converged=stats%converged, &
-                               iterations=stats%iterations, &
-                               final_resid=stats%final_residual)
+                max_iter=opts%max_iterations, &
+                tol_type=opts%tolerance_type, &
+                verbosity=opts%verbosity, converged=stats%converged, &
+                iterations=stats%iterations, &
+                final_resid=stats%final_residual)
         end if
 
         stats%method_used = "bicgstab"
@@ -508,9 +508,9 @@ contains
         type(solver_stats_t), intent(out) :: stats
 
         call gmres_impl(A, b, x, opts%tolerance, opts%max_iterations, &
-                        opts%restart, opts%tolerance_type, opts%verbosity, &
-                        stats%converged, stats%iterations, stats%restarts, &
-                        stats%final_residual)
+            opts%restart, opts%tolerance_type, opts%verbosity, &
+            stats%converged, stats%iterations, stats%restarts, &
+            stats%final_residual)
 
         stats%method_used = "gmres"
     end subroutine gmres_solve
@@ -666,7 +666,7 @@ contains
     end subroutine build_preconditioner
 
     subroutine build_sparse_preconditioner(A_sparse, precond, precond_type, &
-                                           opts)
+            opts)
         type(sparse_matrix_t), intent(in) :: A_sparse
         type(preconditioner_t), intent(out) :: precond
         character(len=*), intent(in) :: precond_type
@@ -742,7 +742,7 @@ contains
             call solve_ilu(precond, r, z)
 
         case default
-            z = r  ! Identity preconditioner
+            z = r ! Identity preconditioner
         end select
     end subroutine apply_preconditioner
 
@@ -810,7 +810,7 @@ contains
                         if (abs(precond%U(i, j)) > 1.0e-14_dp .or. &
                             abs(precond%U(k, j)) > 1.0e-14_dp) then
                             precond%U(i, j) = precond%U(i, j) - &
-                                              factor*precond%U(k, j)
+                                factor*precond%U(k, j)
                         end if
                     end do
                 end if
@@ -910,11 +910,11 @@ contains
 
         select case (trim(method))
         case ("lapack_lu", "direct")
-            memory_bytes = n*n*8  ! Dense storage
+            memory_bytes = n*n*8 ! Dense storage
         case ("cg", "pcg", "bicgstab", "gmres")
-            memory_bytes = n*8*10  ! Several vectors
+            memory_bytes = n*8*10 ! Several vectors
         case default
-            memory_bytes = n*8*5   ! Conservative estimate
+            memory_bytes = n*8*5 ! Conservative estimate
         end select
     end function estimate_memory_usage
 
@@ -939,12 +939,12 @@ contains
 
     ! Constructor function for solver options
     function solver_options(method, tolerance, max_iterations, preconditioner, &
-                            tolerance_type, restart, parallel, num_threads, &
-                            verbosity, drop_tolerance, fill_level) result(opts)
+            tolerance_type, restart, parallel, num_threads, &
+            verbosity, drop_tolerance, fill_level) result(opts)
         character(len=*), intent(in), optional :: method, preconditioner, tolerance_type
         real(dp), intent(in), optional :: tolerance, drop_tolerance
         integer, intent(in), optional :: max_iterations, restart, num_threads, &
-                                         verbosity, fill_level
+            verbosity, fill_level
         logical, intent(in), optional :: parallel
         type(solver_options_t) :: opts
 

--- a/src/solvers/fortfem_krylov_solvers.f90
+++ b/src/solvers/fortfem_krylov_solvers.f90
@@ -8,7 +8,7 @@ module fortfem_krylov_solvers
 contains
 
     subroutine gmres_impl(A, b, x, tol, max_iter, restart, tol_type, verbosity, &
-                          converged, iterations, restarts_count, final_resid)
+            converged, iterations, restarts_count, final_resid)
         real(dp), intent(in) :: A(:, :), b(:)
         real(dp), intent(inout) :: x(:)
         real(dp), intent(in) :: tol
@@ -56,8 +56,8 @@ contains
             H = 0.0_dp
 
             call gmres_arnoldi_cycle(A, V, H, c, s, g, m, total_iter, max_iter, &
-                                     tolerance, verbosity, converged, &
-                                         residual_norm, m_used)
+                tolerance, verbosity, converged, &
+                residual_norm, m_used)
 
             call gmres_solve_update(H, V, g, y, x, m_used)
 
@@ -75,8 +75,8 @@ contains
     end subroutine gmres_impl
 
     subroutine gmres_arnoldi_cycle(A, V, H, c, s, g, m, total_iter, max_iter, &
-                                   tolerance, verbosity, converged, &
-                                       residual_norm, m_used)
+            tolerance, verbosity, converged, &
+            residual_norm, m_used)
         real(dp), intent(in) :: A(:, :)
         real(dp), intent(inout) :: V(:, :), H(:, :), c(:), s(:), g(:)
         integer, intent(in) :: m, max_iter, verbosity
@@ -181,12 +181,12 @@ contains
     end subroutine gmres_solve_update
 
     subroutine bicgstab_impl(A, b, x, precond_diag, precond_L, precond_U, &
-                             use_precond, tol, max_iter, tol_type, verbosity, &
-                             converged, iterations, final_resid)
+            use_precond, tol, max_iter, tol_type, verbosity, &
+            converged, iterations, final_resid)
         real(dp), intent(in) :: A(:, :), b(:)
         real(dp), intent(inout) :: x(:)
         real(dp), intent(in), optional :: precond_diag(:), precond_L(:, :), &
-                                          precond_U(:, :)
+            precond_U(:, :)
         logical, intent(in) :: use_precond
         real(dp), intent(in) :: tol
         integer, intent(in) :: max_iter, verbosity
@@ -230,7 +230,7 @@ contains
             p = r + beta*(p - omega*v)
 
             call bicgstab_matvec_step(A, p, v, z, use_precond, precond_diag, &
-                                      precond_L, precond_U)
+                precond_L, precond_U)
 
             alpha = rho/dot_product(r0, v)
             s = r - alpha*v
@@ -243,7 +243,7 @@ contains
             end if
 
             call bicgstab_matvec_step(A, s, t, y, use_precond, precond_diag, &
-                                      precond_L, precond_U)
+                precond_L, precond_U)
 
             omega = dot_product(t, s)/dot_product(t, t)
 
@@ -278,12 +278,12 @@ contains
     end subroutine bicgstab_impl
 
     subroutine bicgstab_matvec_step(A, input, output, precond_out, use_precond, &
-                                    precond_diag, precond_L, precond_U)
+            precond_diag, precond_L, precond_U)
         real(dp), intent(in) :: A(:, :), input(:)
         real(dp), intent(out) :: output(:), precond_out(:)
         logical, intent(in) :: use_precond
         real(dp), intent(in), optional :: precond_diag(:), precond_L(:, :), &
-                                          precond_U(:, :)
+            precond_U(:, :)
 
         if (use_precond .and. present(precond_L) .and. present(precond_U)) then
             call apply_ilu(precond_L, precond_U, input, precond_out)

--- a/src/solvers/fortfem_solvers_laplacian.f90
+++ b/src/solvers/fortfem_solvers_laplacian.f90
@@ -3,9 +3,9 @@ module fortfem_solvers_laplacian
     use fortfem_api_types, only: function_space_t, function_t, dirichlet_bc_t
     use fortfem_api_forms, only: form_equation_t
     use fortfem_advanced_solvers, only: solver_options_t, solver_stats_t, &
-                                        solver_options, advanced_solve => solve
+        solver_options, advanced_solve => solve
     use basis_q1_quad_2d_module, only: q1_shape_functions, &
-                                       q1_shape_derivatives, q1_jacobian
+        q1_shape_derivatives, q1_jacobian
     use fortfem_solvers_p2, only: solve_laplacian_problem_p2
     implicit none
 
@@ -76,7 +76,7 @@ contains
     end subroutine assemble_laplacian_system
 
     pure subroutine compute_p1_triangle_gradients(x1, y1, x2, y2, x3, y3, &
-                                                  area, grad_x, grad_y)
+            area, grad_x, grad_y)
         real(dp), intent(in) :: x1, y1, x2, y2, x3, y3
         real(dp), intent(out) :: area
         real(dp), intent(out) :: grad_x(3), grad_y(3)
@@ -125,7 +125,7 @@ contains
         y3 = space%mesh%data%vertices(2, v3)
 
         call compute_p1_triangle_gradients(x1, y1, x2, y2, x3, y3, area, bx, &
-                                           by)
+            by)
 
         do i = 1, 3
             do j = 1, 3
@@ -200,7 +200,7 @@ contains
         real(dp) :: xi, eta, weight
         logical :: success
         real(dp), parameter :: gauss_pts(2) = [-0.5773502691896257_dp, &
-                                               0.5773502691896257_dp]
+            0.5773502691896257_dp]
         real(dp), parameter :: gauss_w(2) = [1.0_dp, 1.0_dp]
 
         K_elem = 0.0_dp
@@ -212,7 +212,7 @@ contains
 
                 call q1_shape_derivatives(xi, eta, dN_dxi, dN_deta)
                 call q1_jacobian(xi, eta, coords, jac, det_jac, inv_jac, &
-                                 success)
+                    success)
 
                 if (.not. success) cycle
 
@@ -229,8 +229,8 @@ contains
                 do i = 1, 4
                     do j = 1, 4
                         K_elem(i, j) = K_elem(i, j) + weight* &
-                                       (grad_phys(1, i)*grad_phys(1, j) + &
-                                        grad_phys(2, i)*grad_phys(2, j))
+                            (grad_phys(1, i)*grad_phys(1, j) + &
+                            grad_phys(2, i)*grad_phys(2, j))
                     end do
                     F_elem(i) = F_elem(i) + weight*N(i)
                 end do

--- a/src/solvers/fortfem_solvers_neumann.f90
+++ b/src/solvers/fortfem_solvers_neumann.f90
@@ -95,7 +95,7 @@ contains
         allocate (K(ndof, ndof), F(ndof), ipiv(ndof))
 
         call assemble_laplacian_neumann_system(uh, dirichlet_bc, neumann_bc, &
-                                               K, F)
+            K, F)
 
         call dgesv(ndof, 1, K, ndof, ipiv, F, ndof, info)
 
@@ -111,7 +111,7 @@ contains
     end subroutine solve_laplacian_with_neumann
 
     subroutine assemble_laplacian_neumann_system(uh, dirichlet_bc, &
-                                                 neumann_bc, K, F)
+            neumann_bc, K, F)
         type(function_t), intent(in) :: uh
         type(dirichlet_bc_t), intent(in) :: dirichlet_bc
         type(neumann_bc_t), intent(in) :: neumann_bc

--- a/src/solvers/fortfem_solvers_p2.f90
+++ b/src/solvers/fortfem_solvers_p2.f90
@@ -4,7 +4,7 @@ module fortfem_solvers_p2
     use fortfem_api_types, only: function_t, dirichlet_bc_t
     use fortfem_api_mesh, only: find_triangle_edges
     use fortfem_advanced_solvers, only: solver_options_t, solver_stats_t, &
-                                        solver_options, advanced_solve => solve
+        solver_options, advanced_solve => solve
     use basis_p2_2d_module, only: basis_p2_2d_t
     implicit none
 
@@ -80,7 +80,7 @@ contains
 
             dofs(1:3) = [v1, v2, v3]
             call find_triangle_edges(uh%space%mesh%data, e, edge1, edge2, &
-                                     edge3)
+                edge3)
             dofs(4) = uh%space%mesh%data%n_vertices + edge1
             dofs(5) = uh%space%mesh%data%n_vertices + edge2
             dofs(6) = uh%space%mesh%data%n_vertices + edge3
@@ -92,7 +92,7 @@ contains
                     do j = 1, 6
                         if (dofs(j) > 0 .and. dofs(j) <= ndof) then
                             K(dofs(i), dofs(j)) = K(dofs(i), dofs(j)) + &
-                                                  K_elem(i, j)
+                                K_elem(i, j)
                         end if
                     end do
                     F(dofs(i)) = F(dofs(i)) + F_elem(i)
@@ -118,9 +118,9 @@ contains
         w_q = [1.0_dp/3.0_dp, 1.0_dp/3.0_dp, 1.0_dp/3.0_dp]
 
         area = 0.5_dp*abs((vertices(1, 2) - vertices(1, 1))* &
-                          (vertices(2, 3) - vertices(2, 1)) - &
-                          (vertices(1, 3) - vertices(1, 1))* &
-                          (vertices(2, 2) - vertices(2, 1)))
+            (vertices(2, 3) - vertices(2, 1)) - &
+            (vertices(1, 3) - vertices(1, 1))* &
+            (vertices(2, 2) - vertices(2, 1)))
 
         call basis_p2%compute_jacobian(vertices, jac, det_j)
         inv_jac(1, 1) = jac(2, 2)/det_j
@@ -135,16 +135,16 @@ contains
             do j = 1, 6
                 do kq = 1, 3
                     grad_i = matmul(inv_jac, basis_p2%grad(i, xi_q(kq), &
-                                                           eta_q(kq)))
+                        eta_q(kq)))
                     grad_j = matmul(inv_jac, basis_p2%grad(j, xi_q(kq), &
-                                                           eta_q(kq)))
+                        eta_q(kq)))
                     K_elem(i, j) = K_elem(i, j) + w_q(kq)*area* &
-                                   (grad_i(1)*grad_j(1) + grad_i(2)*grad_j(2))
+                        (grad_i(1)*grad_j(1) + grad_i(2)*grad_j(2))
                 end do
             end do
             do kq = 1, 3
                 F_elem(i) = F_elem(i) + w_q(kq)*area* &
-                            basis_p2%eval(i, xi_q(kq), eta_q(kq))
+                    basis_p2%eval(i, xi_q(kq), eta_q(kq))
             end do
         end do
     end subroutine compute_p2_element_matrices

--- a/src/solvers/fortfem_umfpack_interface.f90
+++ b/src/solvers/fortfem_umfpack_interface.f90
@@ -1,7 +1,7 @@
 module fortfem_umfpack_interface
     use fortfem_kinds, only: dp
     use, intrinsic :: iso_c_binding, only: c_int, c_double, c_ptr, &
-                                           c_null_ptr, c_associated
+        c_null_ptr, c_associated
     implicit none
     private
 
@@ -12,8 +12,8 @@ module fortfem_umfpack_interface
 
     interface
         function umfpack_di_symbolic(n_row, n_col, Ap, Ai, Ax, symbolic, &
-                                     control, info) bind(C, &
-                                                         name="umfpack_di_symbolic")
+                control, info) bind(C, &
+                name="umfpack_di_symbolic")
             import :: c_int, c_double, c_ptr
             integer(c_int), value :: n_row, n_col
             integer(c_int), intent(in) :: Ap(*)
@@ -26,8 +26,8 @@ module fortfem_umfpack_interface
         end function umfpack_di_symbolic
 
         function umfpack_di_numeric(Ap, Ai, Ax, symbolic, numeric, control, &
-                                    info) bind(C, &
-                                               name="umfpack_di_numeric")
+                info) bind(C, &
+                name="umfpack_di_numeric")
             import :: c_int, c_double, c_ptr
             integer(c_int), intent(in) :: Ap(*)
             integer(c_int), intent(in) :: Ai(*)
@@ -40,7 +40,7 @@ module fortfem_umfpack_interface
         end function umfpack_di_numeric
 
         function umfpack_di_solve(sys, Ap, Ai, Ax, x, b, numeric, control, &
-                                  info) bind(C, name="umfpack_di_solve")
+                info) bind(C, name="umfpack_di_solve")
             import :: c_int, c_double, c_ptr
             integer(c_int), value :: sys
             integer(c_int), intent(in) :: Ap(*)
@@ -55,13 +55,13 @@ module fortfem_umfpack_interface
         end function umfpack_di_solve
 
         subroutine umfpack_di_free_symbolic(symbolic) bind(C, &
-                                                           name="umfpack_di_free_symbolic")
+                name="umfpack_di_free_symbolic")
             import :: c_ptr
             type(c_ptr), intent(inout) :: symbolic
         end subroutine umfpack_di_free_symbolic
 
         subroutine umfpack_di_free_numeric(numeric) bind(C, &
-                                                         name="umfpack_di_free_numeric")
+                name="umfpack_di_free_numeric")
             import :: c_ptr
             type(c_ptr), intent(inout) :: numeric
         end subroutine umfpack_di_free_numeric
@@ -84,7 +84,7 @@ contains
     end subroutine check_umfpack_kinds
 
     subroutine build_umfpack_arrays(n, col_ptr, row_ind, values_csc, b, &
-                                    Ap_c, Ai_c, Ax_c, b_c, x_c, n_c)
+            Ap_c, Ai_c, Ax_c, b_c, x_c, n_c)
         integer, intent(in) :: n
         integer, intent(in) :: col_ptr(:)
         integer, intent(in) :: row_ind(:)
@@ -122,7 +122,7 @@ contains
     end subroutine build_umfpack_arrays
 
     subroutine umfpack_factor_and_solve(n_c, Ap_c, Ai_c, Ax_c, b_c, x_c, &
-                                        status)
+            status)
         integer(c_int), intent(in) :: n_c
         integer(c_int), intent(in) :: Ap_c(:)
         integer(c_int), intent(in) :: Ai_c(:)
@@ -138,7 +138,7 @@ contains
         numeric = c_null_ptr
 
         stat_sym = umfpack_di_symbolic(n_c, n_c, Ap_c, Ai_c, Ax_c, symbolic, &
-                                       c_null_ptr, c_null_ptr)
+            c_null_ptr, c_null_ptr)
 
         if (stat_sym /= 0_c_int) then
             status = stat_sym
@@ -149,7 +149,7 @@ contains
         end if
 
         stat_num = umfpack_di_numeric(Ap_c, Ai_c, Ax_c, symbolic, numeric, &
-                                      c_null_ptr, c_null_ptr)
+            c_null_ptr, c_null_ptr)
 
         call umfpack_di_free_symbolic(symbolic)
 
@@ -162,7 +162,7 @@ contains
         end if
 
         stat_solve = umfpack_di_solve(umfpack_sys_A, Ap_c, Ai_c, Ax_c, x_c, &
-                                      b_c, numeric, c_null_ptr, c_null_ptr)
+            b_c, numeric, c_null_ptr, c_null_ptr)
 
         call umfpack_di_free_numeric(numeric)
 
@@ -170,7 +170,7 @@ contains
     end subroutine umfpack_factor_and_solve
 
     subroutine umfpack_solve_csc(n, col_ptr, row_ind, values_csc, b, x, &
-                                 status)
+            status)
         integer, intent(in) :: n
         integer, intent(in) :: col_ptr(:)
         integer, intent(in) :: row_ind(:)
@@ -188,10 +188,10 @@ contains
         call check_umfpack_kinds()
 
         call build_umfpack_arrays(n, col_ptr, row_ind, values_csc, b, Ap_c, &
-                                  Ai_c, Ax_c, b_c, x_c, n_c)
+            Ai_c, Ax_c, b_c, x_c, n_c)
 
         call umfpack_factor_and_solve(n_c, Ap_c, Ai_c, Ax_c, b_c, x_c, &
-                                      status_local)
+            status_local)
 
         do j = 1, n
             x(j) = real(x_c(j), kind=dp)

--- a/src/triangulation/bowyer_watson.f90
+++ b/src/triangulation/bowyer_watson.f90
@@ -36,7 +36,7 @@ contains
     subroutine delaunay_triangulate(input_points, mesh)
         !> Main Delaunay triangulation routine using Bowyer-Watson algorithm.
         !  Robust predicates are always used.
-        real(dp), intent(in) :: input_points(:,:)  ! (2, npoints)
+        real(dp), intent(in) :: input_points(:,:) ! (2, npoints)
         type(mesh_t), intent(out) :: mesh
 
         integer :: i, npoints
@@ -66,7 +66,7 @@ contains
 
         ! Insert each point using Bowyer-Watson algorithm
         ! Adjacency is maintained incrementally in fill_cavity (O(1) overhead)
-        do i = 4, mesh%npoints  ! Start after super-triangle vertices
+        do i = 4, mesh%npoints ! Start after super-triangle vertices
             ! write(*,*) "Inserting point ", i
             call insert_point(mesh, i)
         end do
@@ -240,7 +240,7 @@ contains
             if (mesh%points(verts(i))%x < mesh%points(verts(start_idx))%x) then
                 start_idx = i
             else if (mesh%points(verts(i))%x == mesh%points(verts(start_idx))%x   &
-                .and. mesh%points(verts(i))%y < mesh%points(verts(start_idx))%y) then
+                    .and. mesh%points(verts(i))%y < mesh%points(verts(start_idx))%y) then
                 start_idx = i
             end if
         end do
@@ -292,20 +292,20 @@ contains
         ! Find triangles whose circumcircles contain the new point
         call find_cavity(mesh, point_idx, cavity_triangles, ncavity_triangles)
 
-        if (ncavity_triangles == -1) return  ! Handled via edge splitting
+        if (ncavity_triangles == -1) return ! Handled via edge splitting
 
         if (ncavity_triangles == 0) return
 
         ! Find the boundary of the cavity and external neighbors
         call find_cavity_boundary(mesh, cavity_triangles, ncavity_triangles,     &
-                                  cavity_edges, external_neighbors, ncavity_edges)
+            cavity_edges, external_neighbors, ncavity_edges)
 
         ! Remove triangles in the cavity
         call remove_cavity_triangles(mesh, cavity_triangles, ncavity_triangles)
 
         ! Create new triangles with incremental adjacency updates
         call fill_cavity(mesh, point_idx, cavity_edges, external_neighbors,      &
-                        ncavity_edges)
+            ncavity_edges)
     end subroutine insert_point
 
     subroutine find_cavity(mesh, point_idx, cavity_triangles, ncavity_triangles)
@@ -339,7 +339,7 @@ contains
         ! Step 1: Find seed triangle using walking search
         ! locate_point automatically handles linear fallback if walk fails.
         call locate_point(mesh, point%x, point%y, seed_tri, loc_type,            &
-                         last_triangle)
+            last_triangle)
 
         if (seed_tri == 0) return
 
@@ -516,7 +516,7 @@ contains
         mesh%triangles(t1)%neighbors(1) = t4
         mesh%triangles(t1)%neighbors(2) = t2
         mesh%triangles(t1)%neighbors(3) = find_old_neighbor(mesh, seed_tri,      &
-                                                            v3, v1, edge_idx)
+            v3, v1, edge_idx)
 
         ! t2: (point, v2, v3)
         !   Edge 1 (point-v2): adjacent to t3 if exists, else boundary
@@ -524,7 +524,7 @@ contains
         !   Edge 3 (v3-point): adjacent to t1
         mesh%triangles(t2)%neighbors(1) = t3
         mesh%triangles(t2)%neighbors(2) = find_old_neighbor(mesh, seed_tri,      &
-                                                            v2, v3, edge_idx)
+            v2, v3, edge_idx)
         mesh%triangles(t2)%neighbors(3) = t1
 
         if (has_neighbor .and. v4 > 0) then
@@ -535,7 +535,7 @@ contains
             mesh%triangles(t3)%neighbors(1) = t2
             mesh%triangles(t3)%neighbors(2) = t4
             mesh%triangles(t3)%neighbors(3) = find_old_neighbor(mesh, neighbor,  &
-                                                    v4, v2, neighbor_edge_idx)
+                v4, v2, neighbor_edge_idx)
 
             ! t4: (point, v1, v4)
             !   Edge 1 (point-v1): adjacent to t1
@@ -543,17 +543,17 @@ contains
             !   Edge 3 (v4-point): adjacent to t3
             mesh%triangles(t4)%neighbors(1) = t1
             mesh%triangles(t4)%neighbors(2) = find_old_neighbor(mesh, neighbor,  &
-                                                    v1, v4, neighbor_edge_idx)
+                v1, v4, neighbor_edge_idx)
             mesh%triangles(t4)%neighbors(3) = t3
         end if
 
         ! Update external neighbors to point to new triangles
         call update_external_neighbors_after_split(mesh, seed_tri, t1, t2,       &
-                                                   v1, v2, v3, edge_idx)
+            v1, v2, v3, edge_idx)
         if (has_neighbor .and. v4 > 0) then
             call update_external_neighbors_after_split(mesh, neighbor, t3, t4,   &
-                                                       v2, v1, v4,               &
-                                                       neighbor_edge_idx)
+                v2, v1, v4,               &
+                neighbor_edge_idx)
         end if
 
         ! Update last_triangle for warm start
@@ -583,8 +583,8 @@ contains
     end function find_old_neighbor
 
     subroutine update_external_neighbors_after_split(mesh, old_tri, new_t1,      &
-                                                     new_t2, v1, v2, v3,         &
-                                                     split_edge)
+            new_t2, v1, v2, v3,         &
+            split_edge)
         !> Update external triangles to point to new triangles after edge split.
         type(mesh_t), intent(inout) :: mesh
         integer, intent(in) :: old_tri, new_t1, new_t2, v1, v2, v3, split_edge
@@ -605,15 +605,15 @@ contains
             if ((ev1 == v3 .and. ev2 == v1) .or. (ev1 == v1 .and. ev2 == v3)) then
                 call update_neighbor_link(mesh, neighbor, ev1, ev2, new_t1)
             else if ((ev1 == v2 .and. ev2 == v3) .or.                            &
-                     (ev1 == v3 .and. ev2 == v2)) then
+                    (ev1 == v3 .and. ev2 == v2)) then
                 call update_neighbor_link(mesh, neighbor, ev1, ev2, new_t2)
             end if
         end do
     end subroutine update_external_neighbors_after_split
 
     subroutine find_cavity_boundary(mesh, cavity_triangles, ncavity_triangles,   &
-                                    cavity_edges, external_neighbors,            &
-                                    ncavity_edges)
+            cavity_edges, external_neighbors,            &
+            ncavity_edges)
         !> Find boundary edges of the cavity and their external neighbors.
         !
         !  For each boundary edge, we also store which triangle is on the
@@ -627,8 +627,8 @@ contains
         integer, intent(out) :: ncavity_edges
 
         integer :: all_edges(2, MAX_CAVITY_SIZE * 3)
-        integer :: edge_tri(MAX_CAVITY_SIZE * 3)      ! Which triangle owns edge
-        integer :: edge_idx_in_tri(MAX_CAVITY_SIZE * 3)  ! Edge index in triangle
+        integer :: edge_tri(MAX_CAVITY_SIZE * 3) ! Which triangle owns edge
+        integer :: edge_idx_in_tri(MAX_CAVITY_SIZE * 3) ! Edge index in triangle
         integer :: edge_count(MAX_CAVITY_SIZE * 3)
         integer :: nedges_total, i, j, t, v1, v2
         integer :: edge_idx, tmp, neighbor
@@ -716,7 +716,7 @@ contains
     end subroutine remove_cavity_triangles
 
     subroutine fill_cavity(mesh, point_idx, cavity_edges, external_neighbors,    &
-                           ncavity_edges)
+            ncavity_edges)
         !> Create new triangles with incremental adjacency updates.
         !
         !  Each new triangle has 3 edges:

--- a/src/triangulation/constrained_delaunay.f90
+++ b/src/triangulation/constrained_delaunay.f90
@@ -30,8 +30,8 @@ module constrained_delaunay
 contains
 
     subroutine constrained_delaunay_triangulate(input_points,                 &
-                                               constraint_segments, mesh,     &
-                                               hole_points, final_segments)
+            constraint_segments, mesh,     &
+            hole_points, final_segments)
         !> Constrained Delaunay triangulation with robust predicates.
         !
         !  Uses robust integer coordinate arithmetic throughout to ensure
@@ -84,7 +84,7 @@ contains
 
         do i = 1, size(adjusted_segments, 2)
             call insert_segment(mesh, adjusted_segments(1, i),               &
-                               adjusted_segments(2, i))
+                adjusted_segments(2, i))
         end do
 
         call remove_exterior_triangles(mesh, adjusted_segments)
@@ -306,7 +306,7 @@ contains
                 if (det1 * det2 >= 0.0_dp) cycle
 
                 call do_edge_flip_with_fixup(mesh, t, t2, e1, e2, v_opp1,     &
-                                             v_opp2, va, vb, new_t1, new_t2)
+                    v_opp2, va, vb, new_t1, new_t2)
                 flipped = .true.
                 return
             end do
@@ -314,7 +314,7 @@ contains
     end function flip_one_crossing_edge
 
     subroutine do_edge_flip_with_fixup(mesh, t1, t2, e1, e2, v1, v2, seg_a,   &
-                                       seg_b, new_t1, new_t2)
+            seg_b, new_t1, new_t2)
         !> Flip edge (e1,e2) to edge (v1,v2) and restore Delaunay property.
         !
         !  The edge (e1,e2) is shared by triangles t1 and t2.
@@ -358,7 +358,7 @@ contains
     end subroutine do_edge_flip_with_fixup
 
     recursive subroutine delaunay_fixup(mesh, tri, v_base, v_edge, seg_a,     &
-                                        seg_b, depth)
+            seg_b, depth)
         !> Restore Delaunay property for edges not crossing the constraint.
         !
         !  This is the key routine that makes CDT produce good triangles.
@@ -397,7 +397,7 @@ contains
         ! Find the far vertex in the adjacent triangle
         v_far = get_opposite_vertex(mesh, adj_tri, v_base, v_apex)
         if (v_far == 0) return
-        if (v_far == v_edge) return  ! Degenerate case
+        if (v_far == v_edge) return ! Degenerate case
 
         ! Dont flip constraint edges
         if (is_constraint_edge_static(v_base, v_apex)) return
@@ -419,13 +419,13 @@ contains
         if (incircle_result > 0.0_dp) then
             ! Edge (v_base, v_apex) is not locally Delaunay - flip it
             call flip_edge_simple(mesh, tri, adj_tri, v_base, v_apex, v_edge, &
-                                  v_far, new_t1, new_t2)
+                v_far, new_t1, new_t2)
 
             ! Recursively fix the two new edges
             call delaunay_fixup(mesh, new_t1, v_base, v_edge, seg_a, seg_b,   &
-                                depth + 1)
+                depth + 1)
             call delaunay_fixup(mesh, new_t2, v_apex, v_edge, seg_a, seg_b,   &
-                                depth + 1)
+                depth + 1)
         end if
     end subroutine delaunay_fixup
 
@@ -575,7 +575,7 @@ contains
     end function is_constraint_edge_static
 
     logical function segments_properly_intersect(p1, p2, q1, q2)              &
-        result(intersect)
+            result(intersect)
         !> Test if two segments properly intersect (cross in interiors).
         !
         !  Uses the robust orientation predicate when enabled, so that
@@ -640,7 +640,7 @@ contains
     real(dp) function signed_area(pa, pb, pc)
         type(point_t), intent(in) :: pa, pb, pc
         signed_area = (pb%x - pa%x) * (pc%y - pa%y) -                         &
-                      (pc%x - pa%x) * (pb%y - pa%y)
+            (pc%x - pa%x) * (pb%y - pa%y)
     end function signed_area
 
     integer function find_adjacent_triangle(mesh, tri, v1, v2) result(adj)
@@ -850,7 +850,7 @@ contains
                 virus_pool(pool_tail) = neighbor
             end do
         end do
-        
+
         ! write(*,*) "Total infected triangles:", count(infected)
 
         ! If no valid triangles were infected, there is nothing to remove.

--- a/src/triangulation/delaunay_types.f90
+++ b/src/triangulation/delaunay_types.f90
@@ -1,245 +1,245 @@
 module delaunay_types
     use fortfem_kinds, only: dp
     implicit none
-    
+
     private
     public :: point_t, triangle_t, edge_t, mesh_t
     public :: create_mesh, destroy_mesh, resize_mesh
     public :: add_point, add_triangle, add_edge
     public :: is_valid_triangle, is_valid_edge
-    
+
     ! Point type with coordinates and ID
     type :: point_t
         real(dp) :: x, y
         integer :: id
         logical :: valid = .true.
     end type point_t
-    
+
     ! Triangle type with vertices, neighbors, and validity
     type :: triangle_t
-        integer :: vertices(3)   ! Point indices (1-based)
-        integer :: neighbors(3)  ! Neighbor triangle indices (1-based, 0 = no neighbor)
+        integer :: vertices(3) ! Point indices (1-based)
+        integer :: neighbors(3) ! Neighbor triangle indices (1-based, 0 = no neighbor)
         logical :: valid = .true.
     end type triangle_t
-    
+
     ! Edge type with endpoints and constraint flag
     type :: edge_t
-        integer :: endpoints(2)  ! Point indices (1-based)
+        integer :: endpoints(2) ! Point indices (1-based)
         logical :: constrained = .false.
         logical :: valid = .true.
     end type edge_t
-    
+
     ! Main mesh type containing all geometric data
     type :: mesh_t
         type(point_t), allocatable :: points(:)
         type(triangle_t), allocatable :: triangles(:)
         type(edge_t), allocatable :: edges(:)
-        
+
         integer :: npoints = 0
         integer :: ntriangles = 0
         integer :: nedges = 0
-        
+
         integer :: max_points = 0
         integer :: max_triangles = 0
         integer :: max_edges = 0
-        
+
         ! Super-triangle vertices (for removal after triangulation)
         integer :: super_vertices(3) = 0
     end type mesh_t
-    
+
 contains
 
-subroutine create_mesh(mesh, max_points, max_triangles, max_edges)
-    !> Initialize mesh with given maximum capacities
-    type(mesh_t), intent(out) :: mesh
-    integer, intent(in) :: max_points, max_triangles, max_edges
-    
-    mesh%max_points = max_points
-    mesh%max_triangles = max_triangles
-    mesh%max_edges = max_edges
-    
-    mesh%npoints = 0
-    mesh%ntriangles = 0
-    mesh%nedges = 0
-    
-    allocate(mesh%points(max_points))
-    allocate(mesh%triangles(max_triangles))
-    allocate(mesh%edges(max_edges))
-    
-    mesh%super_vertices = 0
-end subroutine create_mesh
+    subroutine create_mesh(mesh, max_points, max_triangles, max_edges)
+        !> Initialize mesh with given maximum capacities
+        type(mesh_t), intent(out) :: mesh
+        integer, intent(in) :: max_points, max_triangles, max_edges
 
-subroutine destroy_mesh(mesh)
-    !> Clean up mesh memory
-    type(mesh_t), intent(inout) :: mesh
-    
-    if (allocated(mesh%points)) deallocate(mesh%points)
-    if (allocated(mesh%triangles)) deallocate(mesh%triangles)
-    if (allocated(mesh%edges)) deallocate(mesh%edges)
-    
-    mesh%npoints = 0
-    mesh%ntriangles = 0
-    mesh%nedges = 0
-    mesh%max_points = 0
-    mesh%max_triangles = 0
-    mesh%max_edges = 0
-    mesh%super_vertices = 0
-end subroutine destroy_mesh
+        mesh%max_points = max_points
+        mesh%max_triangles = max_triangles
+        mesh%max_edges = max_edges
 
-subroutine resize_mesh(mesh, new_max_points, new_max_triangles, new_max_edges)
-    !> Resize mesh arrays if needed
-    type(mesh_t), intent(inout) :: mesh
-    integer, intent(in) :: new_max_points, new_max_triangles, new_max_edges
-    
-    type(point_t), allocatable :: temp_points(:)
-    type(triangle_t), allocatable :: temp_triangles(:)
-    type(edge_t), allocatable :: temp_edges(:)
-    
-    ! Resize points if needed
-    if (new_max_points > mesh%max_points) then
-        allocate(temp_points(new_max_points))
-        if (mesh%npoints > 0) then
-            temp_points(1:mesh%npoints) = mesh%points(1:mesh%npoints)
+        mesh%npoints = 0
+        mesh%ntriangles = 0
+        mesh%nedges = 0
+
+        allocate(mesh%points(max_points))
+        allocate(mesh%triangles(max_triangles))
+        allocate(mesh%edges(max_edges))
+
+        mesh%super_vertices = 0
+    end subroutine create_mesh
+
+    subroutine destroy_mesh(mesh)
+        !> Clean up mesh memory
+        type(mesh_t), intent(inout) :: mesh
+
+        if (allocated(mesh%points)) deallocate(mesh%points)
+        if (allocated(mesh%triangles)) deallocate(mesh%triangles)
+        if (allocated(mesh%edges)) deallocate(mesh%edges)
+
+        mesh%npoints = 0
+        mesh%ntriangles = 0
+        mesh%nedges = 0
+        mesh%max_points = 0
+        mesh%max_triangles = 0
+        mesh%max_edges = 0
+        mesh%super_vertices = 0
+    end subroutine destroy_mesh
+
+    subroutine resize_mesh(mesh, new_max_points, new_max_triangles, new_max_edges)
+        !> Resize mesh arrays if needed
+        type(mesh_t), intent(inout) :: mesh
+        integer, intent(in) :: new_max_points, new_max_triangles, new_max_edges
+
+        type(point_t), allocatable :: temp_points(:)
+        type(triangle_t), allocatable :: temp_triangles(:)
+        type(edge_t), allocatable :: temp_edges(:)
+
+        ! Resize points if needed
+        if (new_max_points > mesh%max_points) then
+            allocate(temp_points(new_max_points))
+            if (mesh%npoints > 0) then
+                temp_points(1:mesh%npoints) = mesh%points(1:mesh%npoints)
+            end if
+            deallocate(mesh%points)
+            mesh%points = temp_points
+            mesh%max_points = new_max_points
         end if
-        deallocate(mesh%points)
-        mesh%points = temp_points
-        mesh%max_points = new_max_points
-    end if
-    
-    ! Resize triangles if needed
-    if (new_max_triangles > mesh%max_triangles) then
-        allocate(temp_triangles(new_max_triangles))
-        if (mesh%ntriangles > 0) then
-            temp_triangles(1:mesh%ntriangles) = mesh%triangles(1:mesh%ntriangles)
+
+        ! Resize triangles if needed
+        if (new_max_triangles > mesh%max_triangles) then
+            allocate(temp_triangles(new_max_triangles))
+            if (mesh%ntriangles > 0) then
+                temp_triangles(1:mesh%ntriangles) = mesh%triangles(1:mesh%ntriangles)
+            end if
+            deallocate(mesh%triangles)
+            mesh%triangles = temp_triangles
+            mesh%max_triangles = new_max_triangles
         end if
-        deallocate(mesh%triangles)
-        mesh%triangles = temp_triangles
-        mesh%max_triangles = new_max_triangles
-    end if
-    
-    ! Resize edges if needed
-    if (new_max_edges > mesh%max_edges) then
-        allocate(temp_edges(new_max_edges))
-        if (mesh%nedges > 0) then
-            temp_edges(1:mesh%nedges) = mesh%edges(1:mesh%nedges)
+
+        ! Resize edges if needed
+        if (new_max_edges > mesh%max_edges) then
+            allocate(temp_edges(new_max_edges))
+            if (mesh%nedges > 0) then
+                temp_edges(1:mesh%nedges) = mesh%edges(1:mesh%nedges)
+            end if
+            deallocate(mesh%edges)
+            mesh%edges = temp_edges
+            mesh%max_edges = new_max_edges
         end if
-        deallocate(mesh%edges)
-        mesh%edges = temp_edges
-        mesh%max_edges = new_max_edges
-    end if
-end subroutine resize_mesh
+    end subroutine resize_mesh
 
-function add_point(mesh, x, y, point_id) result(index)
-    !> Add a point to the mesh and return its index
-    type(mesh_t), intent(inout) :: mesh
-    real(dp), intent(in) :: x, y
-    integer, intent(in), optional :: point_id
-    integer :: index
-    
-    ! Resize if necessary
-    if (mesh%npoints >= mesh%max_points) then
-        call resize_mesh(mesh, mesh%max_points * 2, mesh%max_triangles, mesh%max_edges)
-    end if
-    
-    mesh%npoints = mesh%npoints + 1
-    index = mesh%npoints
-    
-    mesh%points(index)%x = x
-    mesh%points(index)%y = y
-    mesh%points(index)%valid = .true.
-    
-    if (present(point_id)) then
-        mesh%points(index)%id = point_id
-    else
-        mesh%points(index)%id = index
-    end if
-end function add_point
+    function add_point(mesh, x, y, point_id) result(index)
+        !> Add a point to the mesh and return its index
+        type(mesh_t), intent(inout) :: mesh
+        real(dp), intent(in) :: x, y
+        integer, intent(in), optional :: point_id
+        integer :: index
 
-function add_triangle(mesh, v1, v2, v3) result(index)
-    !> Add a triangle to the mesh and return its index
-    type(mesh_t), intent(inout) :: mesh
-    integer, intent(in) :: v1, v2, v3
-    integer :: index
-    
-    ! Resize if necessary
-    if (mesh%ntriangles >= mesh%max_triangles) then
-        call resize_mesh(mesh, mesh%max_points, mesh%max_triangles * 2, mesh%max_edges)
-    end if
-    
-    mesh%ntriangles = mesh%ntriangles + 1
-    index = mesh%ntriangles
-    
-    mesh%triangles(index)%vertices(1) = v1
-    mesh%triangles(index)%vertices(2) = v2
-    mesh%triangles(index)%vertices(3) = v3
-    mesh%triangles(index)%neighbors = 0  ! No neighbors initially
-    mesh%triangles(index)%valid = .true.
-end function add_triangle
+        ! Resize if necessary
+        if (mesh%npoints >= mesh%max_points) then
+            call resize_mesh(mesh, mesh%max_points * 2, mesh%max_triangles, mesh%max_edges)
+        end if
 
-function add_edge(mesh, v1, v2, constrained) result(index)
-    !> Add an edge to the mesh and return its index
-    type(mesh_t), intent(inout) :: mesh
-    integer, intent(in) :: v1, v2
-    logical, intent(in), optional :: constrained
-    integer :: index
-    
-    ! Resize if necessary
-    if (mesh%nedges >= mesh%max_edges) then
-        call resize_mesh(mesh, mesh%max_points, mesh%max_triangles, mesh%max_edges * 2)
-    end if
-    
-    mesh%nedges = mesh%nedges + 1
-    index = mesh%nedges
-    
-    mesh%edges(index)%endpoints(1) = v1
-    mesh%edges(index)%endpoints(2) = v2
-    mesh%edges(index)%valid = .true.
-    
-    if (present(constrained)) then
-        mesh%edges(index)%constrained = constrained
-    else
-        mesh%edges(index)%constrained = .false.
-    end if
-end function add_edge
+        mesh%npoints = mesh%npoints + 1
+        index = mesh%npoints
 
-logical function is_valid_triangle(mesh, tri_idx)
-    !> Check if triangle index is valid and triangle is valid
-    type(mesh_t), intent(in) :: mesh
-    integer, intent(in) :: tri_idx
-    
-    is_valid_triangle = .false.
-    
-    if (tri_idx < 1 .or. tri_idx > mesh%ntriangles) return
-    if (.not. mesh%triangles(tri_idx)%valid) return
-    
-    ! Check vertex indices
-    if (any(mesh%triangles(tri_idx)%vertices < 1) .or. &
-        any(mesh%triangles(tri_idx)%vertices > mesh%npoints)) return
-    
-    ! Check vertex validity
-    if (.not. all(mesh%points(mesh%triangles(tri_idx)%vertices)%valid)) return
-    
-    is_valid_triangle = .true.
-end function is_valid_triangle
+        mesh%points(index)%x = x
+        mesh%points(index)%y = y
+        mesh%points(index)%valid = .true.
 
-logical function is_valid_edge(mesh, edge_idx)
-    !> Check if edge index is valid and edge is valid
-    type(mesh_t), intent(in) :: mesh
-    integer, intent(in) :: edge_idx
-    
-    is_valid_edge = .false.
-    
-    if (edge_idx < 1 .or. edge_idx > mesh%nedges) return
-    if (.not. mesh%edges(edge_idx)%valid) return
-    
-    ! Check endpoint indices
-    if (any(mesh%edges(edge_idx)%endpoints < 1) .or. &
-        any(mesh%edges(edge_idx)%endpoints > mesh%npoints)) return
-    
-    ! Check endpoint validity
-    if (.not. all(mesh%points(mesh%edges(edge_idx)%endpoints)%valid)) return
-    
-    is_valid_edge = .true.
-end function is_valid_edge
+        if (present(point_id)) then
+            mesh%points(index)%id = point_id
+        else
+            mesh%points(index)%id = index
+        end if
+    end function add_point
+
+    function add_triangle(mesh, v1, v2, v3) result(index)
+        !> Add a triangle to the mesh and return its index
+        type(mesh_t), intent(inout) :: mesh
+        integer, intent(in) :: v1, v2, v3
+        integer :: index
+
+        ! Resize if necessary
+        if (mesh%ntriangles >= mesh%max_triangles) then
+            call resize_mesh(mesh, mesh%max_points, mesh%max_triangles * 2, mesh%max_edges)
+        end if
+
+        mesh%ntriangles = mesh%ntriangles + 1
+        index = mesh%ntriangles
+
+        mesh%triangles(index)%vertices(1) = v1
+        mesh%triangles(index)%vertices(2) = v2
+        mesh%triangles(index)%vertices(3) = v3
+        mesh%triangles(index)%neighbors = 0 ! No neighbors initially
+        mesh%triangles(index)%valid = .true.
+    end function add_triangle
+
+    function add_edge(mesh, v1, v2, constrained) result(index)
+        !> Add an edge to the mesh and return its index
+        type(mesh_t), intent(inout) :: mesh
+        integer, intent(in) :: v1, v2
+        logical, intent(in), optional :: constrained
+        integer :: index
+
+        ! Resize if necessary
+        if (mesh%nedges >= mesh%max_edges) then
+            call resize_mesh(mesh, mesh%max_points, mesh%max_triangles, mesh%max_edges * 2)
+        end if
+
+        mesh%nedges = mesh%nedges + 1
+        index = mesh%nedges
+
+        mesh%edges(index)%endpoints(1) = v1
+        mesh%edges(index)%endpoints(2) = v2
+        mesh%edges(index)%valid = .true.
+
+        if (present(constrained)) then
+            mesh%edges(index)%constrained = constrained
+        else
+            mesh%edges(index)%constrained = .false.
+        end if
+    end function add_edge
+
+    logical function is_valid_triangle(mesh, tri_idx)
+        !> Check if triangle index is valid and triangle is valid
+        type(mesh_t), intent(in) :: mesh
+        integer, intent(in) :: tri_idx
+
+        is_valid_triangle = .false.
+
+        if (tri_idx < 1 .or. tri_idx > mesh%ntriangles) return
+        if (.not. mesh%triangles(tri_idx)%valid) return
+
+        ! Check vertex indices
+        if (any(mesh%triangles(tri_idx)%vertices < 1) .or. &
+            any(mesh%triangles(tri_idx)%vertices > mesh%npoints)) return
+
+        ! Check vertex validity
+        if (.not. all(mesh%points(mesh%triangles(tri_idx)%vertices)%valid)) return
+
+        is_valid_triangle = .true.
+    end function is_valid_triangle
+
+    logical function is_valid_edge(mesh, edge_idx)
+        !> Check if edge index is valid and edge is valid
+        type(mesh_t), intent(in) :: mesh
+        integer, intent(in) :: edge_idx
+
+        is_valid_edge = .false.
+
+        if (edge_idx < 1 .or. edge_idx > mesh%nedges) return
+        if (.not. mesh%edges(edge_idx)%valid) return
+
+        ! Check endpoint indices
+        if (any(mesh%edges(edge_idx)%endpoints < 1) .or. &
+            any(mesh%edges(edge_idx)%endpoints > mesh%npoints)) return
+
+        ! Check endpoint validity
+        if (.not. all(mesh%points(mesh%edges(edge_idx)%endpoints)%valid)) return
+
+        is_valid_edge = .true.
+    end function is_valid_edge
 
 end module delaunay_types

--- a/src/triangulation/geometric_predicates.f90
+++ b/src/triangulation/geometric_predicates.f90
@@ -49,7 +49,7 @@ contains
         !  The bounding box of the points is used to compute the integer
         !  coordinate mapping.
         !
-        real(dp), intent(in) :: points(:,:)  ! (2, npoints)
+        real(dp), intent(in) :: points(:,:) ! (2, npoints)
         integer, intent(in) :: npoints
 
         call init_robust_coords(robust_coords, points, npoints)
@@ -243,15 +243,15 @@ contains
         type(point_t), intent(in) :: pa, pb, pc
         real(dp) :: angles(3)
 
-        real(dp) :: a, b, c  ! Side lengths
+        real(dp) :: a, b, c ! Side lengths
         real(dp) :: cos_a, cos_b, cos_c
         real(dp), parameter :: pi = 3.141592653589793_dp
         real(dp), parameter :: rad_to_deg = 180.0_dp / pi
 
         ! Calculate side lengths
-        a = edge_length(pb, pc)  ! Side opposite to angle A
-        b = edge_length(pa, pc)  ! Side opposite to angle B
-        c = edge_length(pa, pb)  ! Side opposite to angle C
+        a = edge_length(pb, pc) ! Side opposite to angle A
+        b = edge_length(pa, pc) ! Side opposite to angle B
+        c = edge_length(pa, pb) ! Side opposite to angle C
 
         ! Handle degenerate triangles
         if (a <= geometric_tolerance .or. b <= geometric_tolerance              &

--- a/src/triangulation/mesh_refinement.f90
+++ b/src/triangulation/mesh_refinement.f90
@@ -73,7 +73,7 @@ contains
 
             ! Phase 2: Process bad triangles. Continue until no progress.
             call split_all_bad_triangles(mesh, segments, min_angle_deg,       &
-                                         max_area, changed)
+                max_area, changed)
 
             if (.not. changed) exit
         end do
@@ -130,16 +130,16 @@ contains
 
                     if (d2 < r2) then
                         call split_segment_midpoint(mesh, segments, i,        &
-                                                    seg_changed)
+                            seg_changed)
                         if (seg_changed) then
                             changed = .true.
                             found_encroached = .true.
                         end if
-                        exit  ! Segment array changed, restart scan
+                        exit ! Segment array changed, restart scan
                     end if
                 end do
 
-                if (found_encroached) exit  ! Restart from beginning
+                if (found_encroached) exit ! Restart from beginning
             end do
 
             if (.not. found_encroached) exit
@@ -147,7 +147,7 @@ contains
     end subroutine split_all_encroached_segments
 
     subroutine split_all_bad_triangles(mesh, segments, min_angle_deg,         &
-                                       max_area, changed)
+            max_area, changed)
         !> Process ALL bad triangles, not just one.
         !
         !  Uses Triangle-style off-center placement: when the circumcenter
@@ -222,7 +222,7 @@ contains
             if (enc_seg > 0) then
                 ! Split the encroached segment instead of inserting Steiner point
                 call split_segment_midpoint(mesh, segments, enc_seg,          &
-                                            seg_changed)
+                    seg_changed)
                 if (seg_changed) changed = .true.
                 cycle
             end if
@@ -281,9 +281,9 @@ contains
         yao = pc%y - pa%y
 
         ! Compute squared edge lengths
-        dodist = xdo * xdo + ydo * ydo  ! |pa-pb|^2
-        aodist = xao * xao + yao * yao  ! |pa-pc|^2
-        dadist = (pb%x - pc%x)**2 + (pb%y - pc%y)**2  ! |pb-pc|^2
+        dodist = xdo * xdo + ydo * ydo ! |pa-pb|^2
+        aodist = xao * xao + yao * yao ! |pa-pc|^2
+        dadist = (pb%x - pc%x)**2 + (pb%y - pc%y)**2 ! |pb-pc|^2
 
         ! Compute circumcenter relative to pa
         denominator = 2.0_dp * (xdo * yao - xao * ydo)
@@ -410,7 +410,7 @@ contains
     end function vertex_has_triangles
 
     integer function find_encroached_segment_by_point(mesh, segments, p)     &
-        result(seg_idx)
+            result(seg_idx)
         !> Find first segment whose diametral circle contains point p.
         type(mesh_t), intent(in) :: mesh
         integer, allocatable, intent(in) :: segments(:,:)

--- a/src/triangulation/point_location.f90
+++ b/src/triangulation/point_location.f90
@@ -28,8 +28,8 @@ module point_location
     public :: LOCATION_INSIDE, LOCATION_ON_EDGE, LOCATION_NOT_FOUND
 
     ! Location result types
-    integer, parameter :: LOCATION_INSIDE = 1     ! Point strictly inside triangle
-    integer, parameter :: LOCATION_ON_EDGE = 2    ! Point on triangle edge
+    integer, parameter :: LOCATION_INSIDE = 1 ! Point strictly inside triangle
+    integer, parameter :: LOCATION_ON_EDGE = 2 ! Point on triangle edge
     integer, parameter :: LOCATION_NOT_FOUND = -1 ! Point not in triangulation
 
 contains
@@ -47,7 +47,7 @@ contains
         !
         type(mesh_t), intent(inout) :: mesh
 
-        integer, allocatable :: edge_data(:,:)  ! (4, 3*ntriangles)
+        integer, allocatable :: edge_data(:,:) ! (4, 3*ntriangles)
         integer, allocatable :: sorted_idx(:)
         integer :: n_edges, t, e, va, vb, min_v, max_v
         integer :: i, j
@@ -108,8 +108,8 @@ contains
                 if (edges_match(edge_data, sorted_idx(i), sorted_idx(i + 1))) then
                     ! Link the two triangles
                     call link_triangles(mesh, edge_data, sorted_idx(i),          &
-                                       sorted_idx(i + 1))
-                    i = i + 2  ! Skip both edges
+                        sorted_idx(i + 1))
+                    i = i + 2 ! Skip both edges
                     cycle
                 end if
             end if
@@ -162,7 +162,7 @@ contains
         integer, intent(in) :: idx1, idx2
 
         match = (edge_data(1, idx1) == edge_data(1, idx2)) .and.                 &
-                (edge_data(2, idx1) == edge_data(2, idx2))
+            (edge_data(2, idx1) == edge_data(2, idx2))
     end function edges_match
 
     subroutine link_triangles(mesh, edge_data, idx1, idx2)
@@ -295,7 +295,7 @@ contains
                 cycle
             end select
 
-            if (edge_to_cross == 0) exit  ! Should not happen
+            if (edge_to_cross == 0) exit ! Should not happen
 
             ! Move to neighbor across the edge
             next = mesh%triangles(current)%neighbors(edge_to_cross)

--- a/src/triangulation/robust_predicates.f90
+++ b/src/triangulation/robust_predicates.f90
@@ -34,9 +34,9 @@ module robust_predicates
     public :: ORIENT_CCW, ORIENT_CW, ORIENT_COLLINEAR
 
     ! Orientation results
-    integer, parameter :: ORIENT_CCW = 1        ! Counter-clockwise (positive area)
-    integer, parameter :: ORIENT_CW = -1        ! Clockwise (negative area)
-    integer, parameter :: ORIENT_COLLINEAR = 0  ! Collinear (zero area)
+    integer, parameter :: ORIENT_CCW = 1 ! Counter-clockwise (positive area)
+    integer, parameter :: ORIENT_CW = -1 ! Clockwise (negative area)
+    integer, parameter :: ORIENT_COLLINEAR = 0 ! Collinear (zero area)
 
     ! Maximum integer coordinate value.
     !
@@ -46,13 +46,13 @@ module robust_predicates
     ! determinant remains exact (products stay well within the int64 range).
     ! The incircle predicate uses real(dp) arithmetic on the scaled integers;
     ! this is numerically robust for the geometric scales used in FortFEM.
-    integer(int64), parameter :: MAX_ICOOR = 1073741823_int64  ! 2^30 - 1
+    integer(int64), parameter :: MAX_ICOOR = 1073741823_int64 ! 2^30 - 1
 
     !> Robust coordinate system parameters
     type :: robust_coords_t
-        real(dp) :: xmin, ymin       ! Bounding box minimum
-        real(dp) :: xmax, ymax       ! Bounding box maximum
-        real(dp) :: scale            ! Scale factor: integer = scale * (real - min)
+        real(dp) :: xmin, ymin ! Bounding box minimum
+        real(dp) :: xmax, ymax ! Bounding box maximum
+        real(dp) :: scale ! Scale factor: integer = scale * (real - min)
         logical :: initialized = .false.
     end type robust_coords_t
 
@@ -65,7 +65,7 @@ contains
         !  to integers in range [0, MAX_ICOOR].
         !
         type(robust_coords_t), intent(out) :: rc
-        real(dp), intent(in) :: points(:,:)  ! (2, npoints)
+        real(dp), intent(in) :: points(:,:) ! (2, npoints)
         integer, intent(in) :: npoints
 
         real(dp) :: dx, dy, max_extent
@@ -174,7 +174,7 @@ contains
     end function orient2d_robust
 
     logical function incircle_robust(rc, ax, ay, bx, by, cx, cy, dx, dy)                &
-        result(inside)
+            result(inside)
         !> Robust incircle test using integer coordinates.
         !  Uses real(dp) for final determinant to avoid int64 overflow.
         type(robust_coords_t), intent(in) :: rc

--- a/src/triangulation/triangulation_fortran.f90
+++ b/src/triangulation/triangulation_fortran.f90
@@ -40,7 +40,7 @@ contains
     end subroutine triangulate_fortran
 
     subroutine triangulate_with_hole_fortran(points, segments, hole_points,   &
-                                             result, status)
+            result, status)
         !> Triangulate with one or more holes.
         !
         !  hole_points can be either:
@@ -63,13 +63,13 @@ contains
         if (present(status)) status = 0
 
         call constrained_delaunay_triangulate(points, segments, mesh,         &
-                                             hole_points)
+            hole_points)
         call mesh_to_result(mesh, segments, result)
         call destroy_mesh(mesh)
     end subroutine triangulate_with_hole_fortran
 
     subroutine triangulate_with_quality_fortran(points, segments, min_angle,  &
-                                                result, status)
+            result, status)
         real(dp), intent(in) :: points(:,:)
         integer, intent(in) :: segments(:,:)
         real(dp), intent(in) :: min_angle
@@ -87,7 +87,7 @@ contains
         ! Build constrained Delaunay triangulation and capture the final
         ! constraint segment set (including any Steiner splits).
         call constrained_delaunay_triangulate(points, segments, mesh,         &
-                                             final_segments=cdt_segments)
+            final_segments=cdt_segments)
 
         ! Use angle-based refinement only for now; disable area constraint
         ! by setting max_area to a very large value.
@@ -158,7 +158,7 @@ contains
         do i = 1, mesh%ntriangles
             if (mesh%triangles(i)%valid) then
                 if (all(mesh%triangles(i)%vertices >= 1 .and.                 &
-                        mesh%triangles(i)%vertices <= mesh%npoints)) then
+                    mesh%triangles(i)%vertices <= mesh%npoints)) then
                     if (all(mesh%points(mesh%triangles(i)%vertices)%valid)) then
                         valid_triangles = valid_triangles + 1
                     end if
@@ -167,7 +167,7 @@ contains
         end do
 
         call allocate_result(result, valid_points, valid_triangles,           &
-                            size(input_segments, 2))
+            size(input_segments, 2))
 
         valid_points = 0
         do i = 1, mesh%npoints
@@ -182,7 +182,7 @@ contains
         do i = 1, mesh%ntriangles
             if (mesh%triangles(i)%valid) then
                 if (all(mesh%triangles(i)%vertices >= 1 .and.                 &
-                        mesh%triangles(i)%vertices <= mesh%npoints)) then
+                    mesh%triangles(i)%vertices <= mesh%npoints)) then
                     if (all(mesh%points(mesh%triangles(i)%vertices)%valid)) then
                         valid_triangles = valid_triangles + 1
                         result%triangles(1, valid_triangles) =                &
@@ -255,7 +255,7 @@ contains
     end function compute_min_triangle_angle
 
     real(dp) function interior_angle(px, py, qx, qy, rx, ry, pi)              &
-        result(angle_deg)
+            result(angle_deg)
         real(dp), intent(in) :: px, py, qx, qy, rx, ry, pi
         real(dp) :: v1x, v1y, v2x, v2y, dotpr, norm1, norm2, cos_theta
 

--- a/src/triangulation/triangulator.f90
+++ b/src/triangulation/triangulator.f90
@@ -2,30 +2,30 @@ module triangulator
     ! Clean interface between FortFEM mesh API and triangulation backends
     use fortfem_kinds, only: dp
     use triangulation_fortran, only: triangulation_result_t, triangulate_fortran, &
-                                     cleanup_triangulation
+        cleanup_triangulation
     use triangle_io, only: write_triangle_poly_file, ensure_triangle_available, &
         read_triangle_mesh
     implicit none
-    
+
     private
     public :: triangulate_boundary, triangulate_points
-    
+
 contains
 
     subroutine triangulate_boundary(boundary_points, segments, mesh_points, &
-                                   mesh_triangles, n_points, n_triangles)
+            mesh_triangles, n_points, n_triangles)
         !> Triangulate a boundary defined by points and segments using
         !  constrained Delaunay triangulation.
         !
         !  Preferred backend is the Triangle library (external binary),
         !  with a fallback to the internal Fortran CDT implementation
         !  if Triangle is not available.
-        real(dp), intent(in) :: boundary_points(:,:)    ! (2, n_boundary_points)
-        integer, intent(in) :: segments(:,:)            ! (2, n_segments)
-        real(dp), allocatable, intent(out) :: mesh_points(:,:)     ! (2, n_points)
-        integer, allocatable, intent(out) :: mesh_triangles(:,:)   ! (3, n_triangles)
+        real(dp), intent(in) :: boundary_points(:,:) ! (2, n_boundary_points)
+        integer, intent(in) :: segments(:,:) ! (2, n_segments)
+        real(dp), allocatable, intent(out) :: mesh_points(:,:) ! (2, n_points)
+        integer, allocatable, intent(out) :: mesh_triangles(:,:) ! (3, n_triangles)
         integer, intent(out) :: n_points, n_triangles
-        
+
         type(triangulation_result_t) :: result
         character(len=*), parameter :: TRIANGLE_PATH = "/tmp/triangle_bin"
         character(len=*), parameter :: POLY_BASE = "/tmp/fortfem_boundary"
@@ -40,9 +40,9 @@ contains
         if (triangle_ok) then
             ! Write PSLG to .poly file
             call write_triangle_poly_file(POLY_BASE // ".poly",              &
-                                          boundary_points, segments,         &
-                                          size(boundary_points, 2),          &
-                                          size(segments, 2), stat)
+                boundary_points, segments,         &
+                size(boundary_points, 2),          &
+                size(segments, 2), stat)
 
             if (stat == 0) then
                 cmd = trim(TRIANGLE_PATH) // " -pQ " // POLY_BASE // ".poly"
@@ -51,8 +51,8 @@ contains
 
             if (stat == 0) then
                 call read_triangle_mesh(POLY_BASE, mesh_points,              &
-                                        mesh_triangles, n_points,           &
-                                        n_triangles, stat)
+                    mesh_triangles, n_points,           &
+                    n_triangles, stat)
                 if (stat == 0 .and. n_triangles > 0) then
                     return
                 end if
@@ -72,36 +72,36 @@ contains
         mesh_triangles = result%triangles(:, 1:n_triangles)
 
         call cleanup_triangulation(result)
-        
+
     end subroutine triangulate_boundary
 
     subroutine triangulate_points(input_points, mesh_points, mesh_triangles, &
-                                 n_points, n_triangles)
+            n_points, n_triangles)
         !> Triangulate a set of points (unconstrained Delaunay)
-        real(dp), intent(in) :: input_points(:,:)       ! (2, n_input_points)
-        real(dp), allocatable, intent(out) :: mesh_points(:,:)     ! (2, n_points)
-        integer, allocatable, intent(out) :: mesh_triangles(:,:)   ! (3, n_triangles)
+        real(dp), intent(in) :: input_points(:,:) ! (2, n_input_points)
+        real(dp), allocatable, intent(out) :: mesh_points(:,:) ! (2, n_points)
+        integer, allocatable, intent(out) :: mesh_triangles(:,:) ! (3, n_triangles)
         integer, intent(out) :: n_points, n_triangles
-        
+
         type(triangulation_result_t) :: result
         integer, allocatable :: empty_segments(:,:)
-        
+
         allocate(empty_segments(2, 0))
-        
+
         call triangulate_fortran(input_points, empty_segments, result)
-        
+
         n_points = result%npoints
         n_triangles = result%ntriangles
-        
+
         allocate(mesh_points(2, n_points))
         allocate(mesh_triangles(3, n_triangles))
-        
+
         mesh_points = result%points(:, 1:n_points)
         mesh_triangles = result%triangles(:, 1:n_triangles)
-        
+
         call cleanup_triangulation(result)
         deallocate(empty_segments)
-        
+
     end subroutine triangulate_points
 
 end module triangulator

--- a/test/check.f90
+++ b/test/check.f90
@@ -1,19 +1,19 @@
 module check
     implicit none
     private
-    
+
     public :: check_condition
     public :: check_summary
-    
+
     integer :: n_tests = 0
     integer :: n_passed = 0
-    
+
 contains
-    
+
     subroutine check_condition(condition, description)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: description
-        
+
         n_tests = n_tests + 1
         if (condition) then
             n_passed = n_passed + 1
@@ -22,17 +22,17 @@ contains
             print *, "[FAIL] ", description
         end if
     end subroutine check_condition
-    
+
     subroutine check_summary(test_name)
         character(len=*), intent(in) :: test_name
-        
+
         print *, ""
         print *, "=== ", test_name, " Summary ==="
         print *, "Tests passed: ", n_passed, " / ", n_tests
-        
+
         if (n_passed < n_tests) then
             stop 1
         end if
     end subroutine check_summary
-    
+
 end module check

--- a/test/run_all_tests.f90
+++ b/test/run_all_tests.f90
@@ -1,70 +1,70 @@
 program run_all_tests
     ! Master test runner for FortFEM
     ! Runs all unit tests and reports results
-    
+
     implicit none
-    
+
     integer :: n_tests, n_passed, n_failed
     integer :: status
     character(len=100) :: test_name
     logical :: test_passed
-    
+
     print *, "======================================"
     print *, "       FortFEM Test Suite"
     print *, "======================================"
     print *, ""
-    
+
     n_tests = 0
     n_passed = 0
     n_failed = 0
-    
+
     ! New API tests
-    
+
     call run_test("FEniCS-style API", "test_fenics_style_api", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     call run_test("Curl-Curl API", "test_curl_curl_api", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     call run_test("Forms API Simple", "test_forms_api_simple", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     ! Core module tests
     call run_test("Kinds", "test_kinds", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     call run_test("Mesh 1D", "test_mesh_1d", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     call run_test("Mesh 2D", "test_mesh_2d", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
-    
+
+
     call run_test("Basis 1D", "test_basis_1d", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
-    
+
+
     call run_test("P1 Basis 2D", "test_basis_p1_2d", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     call run_test("P2 Basis 2D", "test_basis_p2_2d", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
-    
+
+
     ! Application tests
     call run_test("Simple Poisson", "test_simple_poisson", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     call run_test("Mesh 2D Comprehensive", "test_mesh_2d_comprehensive", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     ! Benchmark tests
     call run_test("Poisson 1D Benchmark", "test_poisson_1d_benchmark", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     call run_test("Poisson 2D Benchmark", "test_poisson_2d_benchmark", status)
     call update_counts(status, n_tests, n_passed, n_failed)
-    
+
     ! Print summary
     print *, ""
     print *, "======================================"
@@ -74,7 +74,7 @@ program run_all_tests
     print '(A,I3)', " Tests passed:    ", n_passed
     print '(A,I3)', " Tests failed:    ", n_failed
     print *, ""
-    
+
     if (n_failed == 0) then
         print *, "✅ ALL TESTS PASSED! 🎉"
         stop 0
@@ -82,22 +82,22 @@ program run_all_tests
         print *, "❌ SOME TESTS FAILED!"
         stop 1
     end if
-    
+
 contains
 
     subroutine run_test(description, test_program, status)
         character(len=*), intent(in) :: description, test_program
         integer, intent(out) :: status
         character(len=256) :: command
-        
+
         print '(A,A,A)', "Running ", trim(description), "..."
-        
+
         ! Build command to run test
         write(command, '(A,A,A)') "fpm test ", trim(test_program), " 2>&1 > test_output.tmp"
-        
+
         ! Execute test
         call execute_command_line(trim(command), exitstat=status)
-        
+
         if (status == 0) then
             print '(A,A,A)', "  ✅ ", trim(description), " passed"
         else
@@ -105,15 +105,15 @@ contains
             ! Show output for failed tests
             call execute_command_line("cat test_output.tmp")
         end if
-        
+
         ! Clean up
         call execute_command_line("rm -f test_output.tmp")
     end subroutine run_test
-    
+
     subroutine update_counts(status, n_tests, n_passed, n_failed)
         integer, intent(in) :: status
         integer, intent(inout) :: n_tests, n_passed, n_failed
-        
+
         n_tests = n_tests + 1
         if (status == 0) then
             n_passed = n_passed + 1

--- a/test/run_convergence_tests.f90
+++ b/test/run_convergence_tests.f90
@@ -2,25 +2,25 @@ program run_convergence_tests
     ! Main test runner for convergence tests
     use fortfem_kinds
     implicit none
-    
+
     logical :: all_passed
     integer :: exit_code
-    
+
     print *, "FortFEM Convergence Test Suite"
     print *, "=============================="
     print *, ""
-    
+
     all_passed = .true.
-    
+
     ! Run tests
     print *, "Running convergence tests against analytical solutions..."
     print *, ""
-    
+
     ! Note: Individual tests would be run as separate executables
     ! This is a framework for organizing the test suite
-    
+
     call run_test_suite(all_passed)
-    
+
     print *, ""
     print *, "Test Summary"
     print *, "============"
@@ -43,14 +43,14 @@ program run_convergence_tests
         print *, "- Solver algorithms"
         exit_code = 1
     end if
-    
+
     call exit(exit_code)
-    
+
 contains
 
     subroutine run_test_suite(all_passed)
         logical, intent(inout) :: all_passed
-        
+
         print *, "Individual test executables:"
         print *, "  test_poisson_1d_convergence  - 1D Poisson O(h²) convergence"
         print *, "  test_poisson_2d_convergence  - 2D Poisson O(h²) convergence"
@@ -58,13 +58,13 @@ contains
         print *, ""
         print *, "Run each test individually to see detailed convergence analysis."
         print *, ""
-        
+
         ! In a full implementation, this would:
         ! 1. Execute each test program
         ! 2. Capture their return codes
         ! 3. Aggregate results
         ! 4. Report overall success/failure
-        
+
         print *, "Framework ready for automated testing."
     end subroutine run_test_suite
 

--- a/test/test_advanced_solvers.f90
+++ b/test/test_advanced_solvers.f90
@@ -1,15 +1,15 @@
 program test_advanced_solvers
     use fortfem_kinds, only: dp
     use fortfem_advanced_solvers, only: solver_options_t, solver_stats_t, &
-                                        solver_options, solve, solve_sparse, &
-                                        jacobi_preconditioner, &
-                                        ilu_preconditioner
+        solver_options, solve, solve_sparse, &
+        jacobi_preconditioner, &
+        ilu_preconditioner
     use fortfem_sparse_matrix, only: sparse_matrix_t, sparse_from_dense, &
-                                     spmv
+        spmv
     use fortfem_umfpack_interface, only: umfpack_available
     use fortfem_api, only: mesh_t, function_space_t, dirichlet_bc_t, &
-                           unit_square_mesh, function_space, dirichlet_bc, &
-                           assemble_laplacian_system
+        unit_square_mesh, function_space, dirichlet_bc, &
+        assemble_laplacian_system
     use check
     implicit none
 
@@ -49,30 +49,30 @@ contains
         ! Set up exact solution and RHS
         x_exact = [(real(i, dp), i=1, n)]
         b = matmul(A, x_exact)
-        x = 0.0_dp  ! Initial guess
+        x = 0.0_dp ! Initial guess
 
         ! Configure CG solver
         opts = solver_options(method="cg", tolerance=1.0e-10_dp, &
-                              max_iterations=n, verbosity=0)
+            max_iterations=n, verbosity=0)
 
         ! Solve system
         call solve(A, b, x, opts, stats)
 
         ! Check convergence
         call check_condition(stats%converged, &
-                             "CG solver: converged")
+            "CG solver: converged")
         call check_condition(stats%iterations < n/2, &
-                             "CG solver: reasonable iteration count")
+            "CG solver: reasonable iteration count")
 
         residual_norm = norm(matmul(A, x) - b)
         error_norm = norm(x - x_exact)
 
         call check_condition(residual_norm < 1.0e-7_dp, &
-                             "CG solver: small residual")
+            "CG solver: small residual")
         call check_condition(error_norm < 1.0e-6_dp, &
-                             "CG solver: accurate solution")
+            "CG solver: accurate solution")
         call check_condition(stats%final_residual < 1.0e-7_dp, &
-                             "CG solver: tolerance achieved")
+            "CG solver: tolerance achieved")
 
         write (*, *) "   CG iterations:", stats%iterations
         write (*, *) "   CG residual:", stats%final_residual
@@ -91,33 +91,33 @@ contains
 
         call create_spd_matrix(n, A)
         allocate (b(n), x_jacobi(n), x_ilu(n))
-        b = 1.0_dp  ! Simple RHS
+        b = 1.0_dp ! Simple RHS
 
         ! Test Jacobi preconditioned CG
         x_jacobi = 0.0_dp
         opts_jacobi = solver_options(method="pcg", preconditioner="jacobi", &
-                                     tolerance=1.0e-8_dp, max_iterations=n)
+            tolerance=1.0e-8_dp, max_iterations=n)
         call solve(A, b, x_jacobi, opts_jacobi, stats_jacobi)
 
         call check_condition(stats_jacobi%converged, &
-                             "PCG Jacobi: converged")
+            "PCG Jacobi: converged")
         call check_condition(stats_jacobi%iterations < n, &
-                             "PCG Jacobi: reasonable iterations")
+            "PCG Jacobi: reasonable iterations")
 
         ! Test ILU preconditioned CG
         x_ilu = 0.0_dp
         opts_ilu = solver_options(method="pcg", preconditioner="ilu", &
-                                  tolerance=1.0e-8_dp, max_iterations=n)
+            tolerance=1.0e-8_dp, max_iterations=n)
         call solve(A, b, x_ilu, opts_ilu, stats_ilu)
 
         call check_condition(stats_ilu%converged, &
-                             "PCG ILU: converged")
+            "PCG ILU: converged")
         call check_condition(stats_ilu%iterations <= stats_jacobi%iterations, &
-                             "PCG ILU: better than Jacobi")
+            "PCG ILU: better than Jacobi")
 
         ! Check both solutions are similar
         call check_condition(norm(x_jacobi - x_ilu) < 1.0e-6_dp, &
-                             "PCG: consistent solutions")
+            "PCG: consistent solutions")
 
         write (*, *) "   Jacobi iterations:", stats_jacobi%iterations
         write (*, *) "   ILU iterations:", stats_ilu%iterations
@@ -145,17 +145,17 @@ contains
         x = 0.0_dp
 
         opts = solver_options(method="bicgstab", tolerance=1.0e-10_dp, &
-                              max_iterations=2*n)
+            max_iterations=2*n)
         call solve(A, b, x, opts, stats)
 
         call check_condition(stats%converged, &
-                             "BiCGSTAB: converged")
+            "BiCGSTAB: converged")
         call check_condition(stats%iterations < n, &
-                             "BiCGSTAB: reasonable iterations")
+            "BiCGSTAB: reasonable iterations")
 
         error_norm = norm(x - x_exact)
         call check_condition(error_norm < 1.0e-8_dp, &
-                             "BiCGSTAB: accurate solution")
+            "BiCGSTAB: accurate solution")
 
         ! Test with preconditioning
         x = 0.0_dp
@@ -163,7 +163,7 @@ contains
         call solve(A, b, x, opts, stats)
 
         call check_condition(stats%converged, &
-                             "BiCGSTAB+ILU: converged")
+            "BiCGSTAB+ILU: converged")
 
         write (*, *) "   BiCGSTAB iterations:", stats%iterations
         write (*, *) "   Error norm:", error_norm
@@ -187,17 +187,17 @@ contains
 
         ! Test GMRES with restart
         opts = solver_options(method="gmres", tolerance=1.0e-8_dp, &
-                              max_iterations=n, restart=30)
+            max_iterations=n, restart=30)
         call solve(A, b, x, opts, stats)
 
         call check_condition(stats%converged, &
-                             "GMRES: converged")
+            "GMRES: converged")
         call check_condition(stats%restarts >= 0, &
-                             "GMRES: restart count tracked")
+            "GMRES: restart count tracked")
 
         residual_norm = norm(matmul(A, x) - b)
         call check_condition(residual_norm < 1.0e-7_dp, &
-                             "GMRES: small residual")
+            "GMRES: small residual")
 
         ! Test flexible GMRES with preconditioning
         x = 0.0_dp
@@ -206,7 +206,7 @@ contains
         call solve(A, b, x, opts, stats)
 
         call check_condition(stats%converged, &
-                             "FGMRES: converged")
+            "FGMRES: converged")
 
         write (*, *) "   GMRES iterations:", stats%iterations
         write (*, *) "   GMRES restarts:", stats%restarts
@@ -234,13 +234,13 @@ contains
         call solve(A, b, x_lu, opts_lu, stats_lu)
 
         call check_condition(stats_lu%converged, &
-                             "Sparse LU: solved")
+            "Sparse LU: solved")
         call check_condition(stats_lu%iterations == 1, &
-                             "Sparse LU: direct method")
+            "Sparse LU: direct method")
 
         error_norm = norm(matmul(A, x_lu) - b)
         call check_condition(error_norm < 1.0e-12_dp, &
-                             "Sparse LU: machine precision accuracy")
+            "Sparse LU: machine precision accuracy")
 
         ! Test UMFPACK if available
         if (umfpack_available()) then
@@ -249,9 +249,9 @@ contains
             call solve(A, b, x_umf, opts_umf, stats_umf)
 
             call check_condition(stats_umf%converged, &
-                                 "UMFPACK: solved")
+                "UMFPACK: solved")
             call check_condition(norm(x_lu - x_umf) < 1.0e-10_dp, &
-                                 "UMFPACK: consistent with LU")
+                "UMFPACK: consistent with LU")
 
             write (*, *) "   UMFPACK available and tested"
         else
@@ -281,10 +281,10 @@ contains
         call solve(A_small, b_small, x_small, opts_auto, stats_small)
 
         call check_condition(stats_small%converged, &
-                             "Auto selection: small system solved")
+            "Auto selection: small system solved")
         call check_condition(index(stats_small%method_used, "lapack") > 0 .or. &
-                             index(stats_small%method_used, "direct") > 0, &
-                             "Auto selection: direct for small system")
+            index(stats_small%method_used, "direct") > 0, &
+            "Auto selection: direct for small system")
 
         ! Large system should use iterative solver
         call create_spd_matrix(1000, A_large)
@@ -295,10 +295,10 @@ contains
         call solve(A_large, b_large, x_large, opts_auto, stats_large)
 
         call check_condition(stats_large%converged, &
-                             "Auto selection: large system solved")
+            "Auto selection: large system solved")
         call check_condition(index(stats_large%method_used, "cg") > 0 .or. &
-                             index(stats_large%method_used, "pcg") > 0, &
-                             "Auto selection: iterative for large system")
+            index(stats_large%method_used, "pcg") > 0, &
+            "Auto selection: iterative for large system")
 
         write (*, *) "   Small system method:", trim(stats_small%method_used)
         write (*, *) "   Large system method:", trim(stats_large%method_used)
@@ -321,13 +321,13 @@ contains
 
         ! Test absolute tolerance
         opts = solver_options(method="cg", tolerance=1.0e-6_dp, &
-                              tolerance_type="absolute")
+            tolerance_type="absolute")
         call solve(A, b, x, opts, stats)
 
         call check_condition(stats%converged, &
-                             "Convergence: absolute tolerance")
+            "Convergence: absolute tolerance")
         call check_condition(stats%final_residual <= opts%tolerance, &
-                             "Convergence: tolerance satisfied")
+            "Convergence: tolerance satisfied")
 
         ! Test relative tolerance
         x = 0.0_dp
@@ -336,7 +336,7 @@ contains
         call solve(A, b, x, opts, stats)
 
         call check_condition(stats%converged, &
-                             "Convergence: relative tolerance")
+            "Convergence: relative tolerance")
 
         ! Test maximum iterations limit
         x = 0.0_dp
@@ -345,9 +345,9 @@ contains
         call solve(A, b, x, opts, stats)
 
         call check_condition(.not. stats%converged, &
-                             "Convergence: max iterations reached")
+            "Convergence: max iterations reached")
         call check_condition(stats%iterations == opts%max_iterations, &
-                             "Convergence: iteration limit enforced")
+            "Convergence: iteration limit enforced")
 
         write (*, *) "   Final residual (abs):", stats%final_residual
         write (*, *) "   Iterations with limit:", stats%iterations
@@ -383,17 +383,17 @@ contains
         time_iter = stats_iter%solve_time
 
         call check_condition(stats_direct%converged, &
-                             "Performance: direct solver works")
+            "Performance: direct solver works")
         call check_condition(stats_iter%converged, &
-                             "Performance: iterative solver works")
+            "Performance: iterative solver works")
 
         speedup = time_direct/time_iter
         call check_condition(norm(x_direct - x_iter) < 1.0e-5_dp, &
-                             "Performance: consistent solutions")
+            "Performance: consistent solutions")
 
         ! Memory usage comparison
         call check_condition(stats_iter%memory_usage < stats_direct%memory_usage, &
-                             "Performance: iterative uses less memory")
+            "Performance: iterative uses less memory")
 
         write (*, *) "   Direct solve time:", time_direct
         write (*, *) "   Iterative solve time:", time_iter
@@ -420,21 +420,21 @@ contains
         x = 0.0_dp
 
         call check_condition(condition_number > 1.0e8_dp, &
-                             "Ill-conditioned: high condition number")
+            "Ill-conditioned: high condition number")
 
         ! Test CG with preconditioning
         opts = solver_options(method="pcg", preconditioner="ilu", &
-                              tolerance=1.0e-6_dp, max_iterations=n*2)
+            tolerance=1.0e-6_dp, max_iterations=n*2)
         call solve(A, b, x, opts, stats)
 
         call check_condition(stats%converged .or. stats%iterations < n*2, &
-                             "Ill-conditioned: reasonable behavior")
+            "Ill-conditioned: reasonable behavior")
 
         residual_norm = norm(matmul(A, x) - b)
 
         ! Even if not fully converged, should make progress
         call check_condition(residual_norm < norm(b), &
-                             "Ill-conditioned: residual reduction")
+            "Ill-conditioned: residual reduction")
 
         write (*, *) "   Condition number:", condition_number
         write (*, *) "   Final residual:", residual_norm
@@ -458,15 +458,15 @@ contains
 
         ! Test parallel CG if available
         opts = solver_options(method="pcg", preconditioner="jacobi", &
-                              parallel=.true., num_threads=2)
+            parallel=.true., num_threads=2)
         call solve(A, b, x, opts, stats)
 
         call check_condition(stats%converged, &
-                             "Parallel: solver converged")
+            "Parallel: solver converged")
 
         if (stats%parallel_efficiency > 0.0_dp) then
             call check_condition(stats%parallel_efficiency > 0.5_dp, &
-                                 "Parallel: reasonable efficiency")
+                "Parallel: reasonable efficiency")
             write (*, *) "   Parallel efficiency:", stats%parallel_efficiency
         else
             write (*, *) "   Parallel efficiency not measured"
@@ -484,7 +484,7 @@ contains
 
         n_mesh = 32
         call setup_laplacian_test_system(n_mesh, K, F, x_direct, ndof, &
-                                         residual_direct)
+            residual_direct)
 
         call test_laplacian_pcg_ilu(K, F, x_direct, ndof, stats_pcg)
         call test_laplacian_bicgstab_ilu(K, F, x_direct, ndof, stats_bicg)
@@ -505,7 +505,7 @@ contains
     end subroutine test_laplacian_large_system_solvers
 
     subroutine setup_laplacian_test_system(n_mesh, K, F, x_direct, ndof, &
-                                           residual_direct)
+            residual_direct)
         integer, intent(in) :: n_mesh
         real(dp), allocatable, intent(out) :: K(:, :), F(:), x_direct(:)
         integer, intent(out) :: ndof
@@ -528,15 +528,15 @@ contains
         x_direct = 0.0_dp
 
         opts_direct = solver_options(method="lapack_lu", &
-                                     tolerance=1.0e-10_dp, max_iterations=ndof)
+            tolerance=1.0e-10_dp, max_iterations=ndof)
         call solve(K, F, x_direct, opts_direct, stats_direct)
 
         call check_condition(stats_direct%converged, &
-                             "Laplacian: direct solver converged")
+            "Laplacian: direct solver converged")
 
         residual_direct = norm(matmul(K, x_direct) - F)
         call check_condition(residual_direct < 1.0e-8_dp, &
-                             "Laplacian: direct residual small")
+            "Laplacian: direct residual small")
     end subroutine setup_laplacian_test_system
 
     subroutine test_laplacian_pcg_ilu(K, F, x_direct, ndof, stats_pcg)
@@ -553,21 +553,21 @@ contains
         x_pcg = 0.0_dp
 
         opts_pcg = solver_options(method="pcg", preconditioner="ilu", &
-                                  tolerance=target_tolerance, &
-                                  tolerance_type="absolute", &
-                                  max_iterations=5*ndof)
+            tolerance=target_tolerance, &
+            tolerance_type="absolute", &
+            max_iterations=5*ndof)
         call solve(K, F, x_pcg, opts_pcg, stats_pcg)
 
         residual_pcg = norm(matmul(K, x_pcg) - F)
         call check_condition(stats_pcg%converged .or. &
-                             residual_pcg <= target_tolerance, &
-                             "Laplacian: PCG+ILU converged")
+            residual_pcg <= target_tolerance, &
+            "Laplacian: PCG+ILU converged")
         call check_condition(residual_pcg < target_tolerance, &
-                             "Laplacian: PCG residual small")
+            "Laplacian: PCG residual small")
 
         error_pcg = norm(x_pcg - x_direct)/max(norm(x_direct), 1.0e-12_dp)
         call check_condition(error_pcg < 1.0e-4_dp, &
-                             "Laplacian: PCG matches direct")
+            "Laplacian: PCG matches direct")
     end subroutine test_laplacian_pcg_ilu
 
     subroutine test_laplacian_bicgstab_ilu(K, F, x_direct, ndof, stats_bicg)
@@ -584,21 +584,21 @@ contains
         x_bicg = 0.0_dp
 
         opts_bicg = solver_options(method="bicgstab", preconditioner="ilu", &
-                                   tolerance=target_tolerance, &
-                                   tolerance_type="absolute", &
-                                   max_iterations=5*ndof)
+            tolerance=target_tolerance, &
+            tolerance_type="absolute", &
+            max_iterations=5*ndof)
         call solve(K, F, x_bicg, opts_bicg, stats_bicg)
 
         residual_bicg = norm(matmul(K, x_bicg) - F)
         call check_condition(stats_bicg%converged .or. &
-                             residual_bicg <= target_tolerance, &
-                             "Laplacian: BiCGSTAB+ILU converged")
+            residual_bicg <= target_tolerance, &
+            "Laplacian: BiCGSTAB+ILU converged")
         call check_condition(residual_bicg < target_tolerance, &
-                             "Laplacian: BiCGSTAB residual small")
+            "Laplacian: BiCGSTAB residual small")
 
         error_bicg = norm(x_bicg - x_direct)/max(norm(x_direct), 1.0e-12_dp)
         call check_condition(error_bicg < 1.0e-4_dp, &
-                             "Laplacian: BiCGSTAB matches direct")
+            "Laplacian: BiCGSTAB matches direct")
     end subroutine test_laplacian_bicgstab_ilu
 
     subroutine test_laplacian_gmres(K, F, x_direct, ndof, stats_gmres)
@@ -614,18 +614,18 @@ contains
         x_gmres = 0.0_dp
 
         opts_gmres = solver_options(method="gmres", tolerance=1.0e-8_dp, &
-                                    max_iterations=5*ndof, restart=50)
+            max_iterations=5*ndof, restart=50)
         call solve(K, F, x_gmres, opts_gmres, stats_gmres)
 
         call check_condition(stats_gmres%converged, "Laplacian: GMRES converged")
 
         residual_gmres = norm(matmul(K, x_gmres) - F)
         call check_condition(residual_gmres < 1.0e-7_dp, &
-                             "Laplacian: GMRES residual small")
+            "Laplacian: GMRES residual small")
 
         error_gmres = norm(x_gmres - x_direct)/max(norm(x_direct), 1.0e-12_dp)
         call check_condition(error_gmres < 1.0e-4_dp, &
-                             "Laplacian: GMRES matches direct")
+            "Laplacian: GMRES matches direct")
     end subroutine test_laplacian_gmres
 
     subroutine test_laplacian_sparse_pcg(K, F, x_direct, ndof, stats_sparse)
@@ -645,19 +645,19 @@ contains
         call sparse_from_dense(K, K_sparse)
 
         opts_sparse = solver_options(method="pcg", preconditioner="jacobi", &
-                                     tolerance=target_tolerance, &
-                                     tolerance_type="absolute", &
-                                     max_iterations=5*ndof)
+            tolerance=target_tolerance, &
+            tolerance_type="absolute", &
+            max_iterations=5*ndof)
         call solve_sparse(K_sparse, F, x_sparse, opts_sparse, stats_sparse)
 
         residual_sparse = norm(matmul(K, x_sparse) - F)
         call check_condition(stats_sparse%converged .or. &
-                             residual_sparse <= target_tolerance, &
-                             "Laplacian: sparse PCG converged")
+            residual_sparse <= target_tolerance, &
+            "Laplacian: sparse PCG converged")
 
         error_sparse = norm(x_sparse - x_direct)/max(norm(x_direct), 1.0e-12_dp)
         call check_condition(error_sparse < 1.0e-4_dp, &
-                             "Laplacian: sparse PCG matches direct")
+            "Laplacian: sparse PCG matches direct")
     end subroutine test_laplacian_sparse_pcg
 
     ! Helper functions for test matrix creation
@@ -710,7 +710,7 @@ contains
             end if
             if (i < n) then
                 call random_number(random_val)
-                A(i, i + 1) = -0.7_dp*random_val  ! Different from lower
+                A(i, i + 1) = -0.7_dp*random_val ! Different from lower
             end if
         end do
     end subroutine create_nonsymmetric_matrix
@@ -731,8 +731,8 @@ contains
 
         do i = 1, n
             A(i, i) = smallest_eigenvalue + &
-                      (largest_eigenvalue - smallest_eigenvalue)* &
-                      real(i - 1, dp)/real(n - 1, dp)
+                (largest_eigenvalue - smallest_eigenvalue)* &
+                real(i - 1, dp)/real(n - 1, dp)
         end do
 
         condition_number = largest_eigenvalue/smallest_eigenvalue
@@ -760,7 +760,7 @@ contains
         call spmv(As, x, y_sparse)
 
         call check_condition(all(abs(y_dense - y_sparse) < 1.0e-12_dp), &
-                             "Sparse matrix: spmv matches dense matmul")
+            "Sparse matrix: spmv matches dense matmul")
 
         deallocate (Ad, x, y_dense, y_sparse)
     end subroutine test_sparse_matrix_type
@@ -783,15 +783,15 @@ contains
         x_sparse = 0.0_dp
 
         opts = solver_options(method="pcg", preconditioner="jacobi", &
-                              tolerance=1.0e-8_dp, max_iterations=n)
+            tolerance=1.0e-8_dp, max_iterations=n)
         call solve(Ad, b, x_dense, opts, stats_dense)
         call solve_sparse(As, b, x_sparse, opts, stats_sparse)
 
         call check_condition(stats_sparse%converged, &
-                             "Sparse PCG: converged with Jacobi")
+            "Sparse PCG: converged with Jacobi")
         error_norm = norm(x_dense - x_sparse)
         call check_condition(error_norm < 1.0e-6_dp, &
-                             "Sparse PCG: solution close to dense path")
+            "Sparse PCG: solution close to dense path")
 
         deallocate (Ad, b, x_dense, x_sparse)
     end subroutine test_pcg_sparse_preconditioners
@@ -814,19 +814,19 @@ contains
         x_sparse = 0.0_dp
 
         opts = solver_options(method="pcg", preconditioner="ilu", &
-                              tolerance=1.0e-8_dp, max_iterations=n)
+            tolerance=1.0e-8_dp, max_iterations=n)
 
         call solve(Ad, b, x_dense, opts, stats_dense)
         call solve_sparse(As, b, x_sparse, opts, stats_sparse)
 
         call check_condition(stats_dense%converged, &
-                             "Dense PCG ILU: converged")
+            "Dense PCG ILU: converged")
         call check_condition(stats_sparse%converged, &
-                             "Sparse PCG ILU: converged")
+            "Sparse PCG ILU: converged")
 
         error_norm = norm(x_dense - x_sparse)
         call check_condition(error_norm < 1.0e-6_dp, &
-                             "Sparse PCG ILU: solution close to dense path")
+            "Sparse PCG ILU: solution close to dense path")
 
         deallocate (Ad, b, x_dense, x_sparse)
     end subroutine test_pcg_sparse_ilu_preconditioner

--- a/test/test_assembly_advanced.f90
+++ b/test/test_assembly_advanced.f90
@@ -5,7 +5,7 @@ program test_assembly_advanced
     implicit none
 
     write(*,*) "Testing advanced assembly system features..."
-    
+
     call test_mass_matrix_properties()
     call test_stiffness_matrix_properties()
     call test_element_matrix_properties()
@@ -13,7 +13,7 @@ program test_assembly_advanced
     call test_assembly_scaling()
     call test_mesh_quality_effects()
     call test_reference_element_mapping()
-    
+
     call check_summary("Advanced Assembly System")
 
 contains
@@ -28,36 +28,36 @@ contains
         type(dirichlet_bc_t) :: bc
         type(form_expr_t) :: a, L
         real(dp) :: total_mass, expected_mass
-        
+
         ! Test on unit square where we can compute expected mass
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Estimate total mass by integrating constant function
         ! For unit square, ∫ 1 dx = 1
-        total_mass = sum(uh%values) * (1.0_dp / Vh%ndof)  ! Approximate integration
+        total_mass = sum(uh%values) * (1.0_dp / Vh%ndof) ! Approximate integration
         expected_mass = 1.0_dp
-        
+
         call check_condition(total_mass > 0.0_dp, &
             "Mass matrix: positive total mass")
-        
+
         write(*,*) "   Approximate total mass:", total_mass
         write(*,*) "   Expected mass (unit square):", expected_mass
     end subroutine test_mass_matrix_properties
 
-    ! Test stiffness matrix properties  
+    ! Test stiffness matrix properties
     subroutine test_stiffness_matrix_properties()
         type(mesh_t) :: mesh
         type(function_space_t) :: Vh
@@ -67,38 +67,38 @@ contains
         type(dirichlet_bc_t) :: bc1, bc2
         type(form_expr_t) :: a, L
         real(dp) :: energy1, energy2
-        
+
         ! Test stiffness matrix positive definiteness through energy
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         ! Solve with different boundary conditions
         bc1 = dirichlet_bc(Vh, 0.0_dp)
         uh1 = function(Vh)
         call solve(a == L, uh1, bc1)
-        
+
         bc2 = dirichlet_bc(Vh, 0.5_dp)
         uh2 = function(Vh)
         call solve(a == L, uh2, bc2)
-        
+
         ! Compute approximate energies
         energy1 = sum(uh1%values**2)
         energy2 = sum(uh2%values**2)
-        
+
         call check_condition(energy1 >= 0.0_dp, &
             "Stiffness matrix: non-negative energy 1")
         call check_condition(energy2 >= 0.0_dp, &
             "Stiffness matrix: non-negative energy 2")
         call check_condition(energy2 > energy1, &
             "Stiffness matrix: larger BC gives larger energy")
-        
+
         write(*,*) "   Energy with BC=0:", energy1
         write(*,*) "   Energy with BC=0.5:", energy2
         write(*,*) "   Energy ratio:", energy2/energy1
@@ -112,42 +112,42 @@ contains
         integer :: i, j, e, v1, v2, v3
         real(dp) :: trace_K, det_K_2x2, sum_off_diag
         logical :: symmetric_element
-        
+
         ! Test element matrix properties on first triangle
         mesh = unit_square_mesh(4)
-        e = 1  ! First triangle
-        
+        e = 1 ! First triangle
+
         v1 = mesh%data%triangles(1, e)
         v2 = mesh%data%triangles(2, e)
         v3 = mesh%data%triangles(3, e)
-        
+
         x1 = mesh%data%vertices(1, v1)
         y1 = mesh%data%vertices(2, v1)
         x2 = mesh%data%vertices(1, v2)
         y2 = mesh%data%vertices(2, v2)
         x3 = mesh%data%vertices(1, v3)
         y3 = mesh%data%vertices(2, v3)
-        
+
         area = 0.5_dp * abs((x2-x1)*(y3-y1) - (x3-x1)*(y2-y1))
-        
+
         ! Compute element matrix (from assembly code)
         a(1,1) = x2 - x1; a(1,2) = x3 - x1
         a(2,1) = y2 - y1; a(2,2) = y3 - y1
         det_a = a(1,1)*a(2,2) - a(1,2)*a(2,1)
-        
+
         b(1) = (-a(2,2) + a(2,1)) / det_a
         c(1) = ( a(1,2) - a(1,1)) / det_a
         b(2) = a(2,2) / det_a
         c(2) = -a(1,2) / det_a
         b(3) = -a(2,1) / det_a
         c(3) = a(1,1) / det_a
-        
+
         do i = 1, 3
             do j = 1, 3
                 K_elem(i,j) = area * (b(i)*b(j) + c(i)*c(j))
             end do
         end do
-        
+
         ! Test symmetry
         symmetric_element = .true.
         do i = 1, 3
@@ -157,11 +157,11 @@ contains
                 end if
             end do
         end do
-        
+
         ! Test trace and other properties
         trace_K = K_elem(1,1) + K_elem(2,2) + K_elem(3,3)
         sum_off_diag = K_elem(1,2) + K_elem(1,3) + K_elem(2,3)
-        
+
         call check_condition(symmetric_element, &
             "Element matrix: symmetry")
         call check_condition(trace_K > 0.0_dp, &
@@ -170,7 +170,7 @@ contains
             "Element matrix: positive area")
         call check_condition(abs(det_a) > 1.0e-12_dp, &
             "Element matrix: non-singular Jacobian")
-        
+
         write(*,*) "   Element area:", area
         write(*,*) "   Jacobian determinant:", det_a
         write(*,*) "   Element matrix trace:", trace_K
@@ -189,16 +189,16 @@ contains
         type(form_expr_t) :: a1, a2, L1, L2
         real(dp) :: integral1, integral2, convergence_rate
         integer :: dof1, dof2
-        
+
         ! Test integration accuracy through mesh refinement
-        mesh1 = unit_square_mesh(4)   ! Coarse
-        mesh2 = unit_square_mesh(8)   ! Fine
-        
+        mesh1 = unit_square_mesh(4) ! Coarse
+        mesh2 = unit_square_mesh(8) ! Fine
+
         Vh1 = function_space(mesh1, "Lagrange", 1)
         Vh2 = function_space(mesh2, "Lagrange", 1)
         dof1 = Vh1%ndof
         dof2 = Vh2%ndof
-        
+
         ! Solve same problem on both meshes
         u1 = trial_function(Vh1)
         v1 = test_function(Vh1)
@@ -208,7 +208,7 @@ contains
         bc1 = dirichlet_bc(Vh1, 0.0_dp)
         uh1 = function(Vh1)
         call solve(a1 == L1, uh1, bc1)
-        
+
         u2 = trial_function(Vh2)
         v2 = test_function(Vh2)
         f2 = constant(1.0_dp)
@@ -217,14 +217,14 @@ contains
         bc2 = dirichlet_bc(Vh2, 0.0_dp)
         uh2 = function(Vh2)
         call solve(a2 == L2, uh2, bc2)
-        
+
         ! Approximate integrals
         integral1 = sum(uh1%values) / real(dof1, dp)
         integral2 = sum(uh2%values) / real(dof2, dp)
-        
+
         call check_condition(integral2 > integral1, &
             "Quadrature accuracy: convergence with refinement")
-        
+
         ! Test that the change is significant and in the right direction
         if (integral1 > 1.0e-12_dp) then
             convergence_rate = abs(integral2 - integral1) / integral1
@@ -234,7 +234,7 @@ contains
             call check_condition(.true., &
                 "Quadrature accuracy: baseline integral too small")
         end if
-        
+
         write(*,*) "   Coarse DOFs:", dof1, "Integral:", integral1
         write(*,*) "   Fine DOFs:", dof2, "Integral:", integral2
         write(*,*) "   Relative change:", abs(integral2 - integral1) / integral1
@@ -251,39 +251,39 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: max_vals(3), h_values(3)
         integer :: n_values(3), i
-        
+
         n_values = [4, 6, 8]
         h_values = 1.0_dp / real(n_values, dp)
-        
+
         ! Test scaling of solution maximum with mesh size
         do i = 1, 3
             mesh = unit_square_mesh(n_values(i))
             Vh = function_space(mesh, "Lagrange", 1)
-            
+
             u = trial_function(Vh)
             v = test_function(Vh)
             f = constant(1.0_dp)
-            
+
             a = inner(grad(u), grad(v))*dx
             L = f*v*dx
-            
+
             bc = dirichlet_bc(Vh, 0.0_dp)
             uh = function(Vh)
-            
+
             call solve(a == L, uh, bc)
             max_vals(i) = maxval(uh%values)
         end do
-        
+
         ! Test convergence: finer mesh should give more accurate (higher) maximum
         call check_condition(max_vals(2) > max_vals(1), &
             "Assembly scaling: refinement increases accuracy 1")
         call check_condition(max_vals(3) > max_vals(2), &
             "Assembly scaling: refinement increases accuracy 2")
-        
+
         ! Values should be bounded
         call check_condition(maxval(max_vals) < 0.15_dp, &
             "Assembly scaling: solution remains bounded")
-        
+
         write(*,*) "   Mesh sizes:", n_values
         write(*,*) "   Max values:", max_vals
         write(*,*) "   h values:", h_values
@@ -298,56 +298,56 @@ contains
         real(dp) :: edge1, edge2, edge3, semiperimeter, quality
         real(dp) :: min_quality, max_quality, avg_quality
         integer :: valid_elements, poor_quality_count
-        
+
         ! Analyze mesh quality on moderately refined mesh
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         min_quality = 1.0_dp
         max_quality = 0.0_dp
         avg_quality = 0.0_dp
         valid_elements = 0
         poor_quality_count = 0
-        
+
         ! Compute quality for each triangle
         do e = 1, mesh%data%n_triangles
             v1 = mesh%data%triangles(1, e)
             v2 = mesh%data%triangles(2, e)
             v3 = mesh%data%triangles(3, e)
-            
+
             x1 = mesh%data%vertices(1, v1)
             y1 = mesh%data%vertices(2, v1)
             x2 = mesh%data%vertices(1, v2)
             y2 = mesh%data%vertices(2, v2)
             x3 = mesh%data%vertices(1, v3)
             y3 = mesh%data%vertices(2, v3)
-            
+
             area = 0.5_dp * abs((x2-x1)*(y3-y1) - (x3-x1)*(y2-y1))
-            
+
             if (area > 1.0e-12_dp) then
                 ! Compute edge lengths
                 edge1 = sqrt((x2-x1)**2 + (y2-y1)**2)
                 edge2 = sqrt((x3-x2)**2 + (y3-y2)**2)
                 edge3 = sqrt((x1-x3)**2 + (y1-y3)**2)
-                
+
                 semiperimeter = 0.5_dp * (edge1 + edge2 + edge3)
-                
+
                 if (semiperimeter > 1.0e-12_dp) then
                     ! Quality = area / (semiperimeter^2), normalized
                     quality = 4.0_dp * sqrt(3.0_dp) * area / (edge1**2 + edge2**2 + edge3**2)
-                    
+
                     min_quality = min(min_quality, quality)
                     max_quality = max(max_quality, quality)
                     avg_quality = avg_quality + quality
                     valid_elements = valid_elements + 1
-                    
+
                     if (quality < 0.5_dp) poor_quality_count = poor_quality_count + 1
                 end if
             end if
         end do
-        
+
         if (valid_elements > 0) avg_quality = avg_quality / real(valid_elements, dp)
-        
+
         call check_condition(valid_elements > 0, &
             "Mesh quality: found valid elements")
         call check_condition(min_quality > 0.0_dp, &
@@ -356,7 +356,7 @@ contains
             "Mesh quality: reasonable average quality")
         call check_condition(real(poor_quality_count, dp) / real(valid_elements, dp) < 0.5_dp, &
             "Mesh quality: most elements have acceptable quality")
-        
+
         write(*,*) "   Total triangles:", mesh%data%n_triangles
         write(*,*) "   Valid elements:", valid_elements
         write(*,*) "   Quality range: [", min_quality, ",", max_quality, "]"
@@ -375,54 +375,54 @@ contains
         real(dp) :: x_expected(3), y_expected(3)
         logical :: mapping_correct
         integer :: i
-        
+
         ! Test mapping on first triangle
         mesh = unit_square_mesh(4)
         e = 1
-        
+
         v1 = mesh%data%triangles(1, e)
         v2 = mesh%data%triangles(2, e)
         v3 = mesh%data%triangles(3, e)
-        
+
         x1 = mesh%data%vertices(1, v1)
         y1 = mesh%data%vertices(2, v1)
         x2 = mesh%data%vertices(1, v2)
         y2 = mesh%data%vertices(2, v2)
         x3 = mesh%data%vertices(1, v3)
         y3 = mesh%data%vertices(2, v3)
-        
+
         ! Jacobian matrix
         a(1,1) = x2 - x1; a(1,2) = x3 - x1
         a(2,1) = y2 - y1; a(2,2) = y3 - y1
         det_a = a(1,1)*a(2,2) - a(1,2)*a(2,1)
-        
+
         ! Test points on reference triangle
         xi_vals  = [0.0_dp, 1.0_dp, 0.0_dp]
         eta_vals = [0.0_dp, 0.0_dp, 1.0_dp]
         x_expected = [x1, x2, x3]
         y_expected = [y1, y2, y3]
-        
+
         mapping_correct = .true.
-        
+
         ! Test mapping: x = x1 + a11*xi + a12*eta, y = y1 + a21*xi + a22*eta
         do i = 1, 3
             xi = xi_vals(i)
             eta = eta_vals(i)
-            
+
             x_phys = x1 + a(1,1)*xi + a(1,2)*eta
             y_phys = y1 + a(2,1)*xi + a(2,2)*eta
-            
+
             if (abs(x_phys - x_expected(i)) > 1.0e-12_dp .or. &
                 abs(y_phys - y_expected(i)) > 1.0e-12_dp) then
                 mapping_correct = .false.
             end if
         end do
-        
+
         call check_condition(abs(det_a) > 1.0e-12_dp, &
             "Reference mapping: non-singular Jacobian")
         call check_condition(mapping_correct, &
             "Reference mapping: vertices map correctly")
-        
+
         write(*,*) "   Test element:", e
         write(*,*) "   Jacobian determinant:", det_a
         write(*,*) "   Vertex 1: (", x1, ",", y1, ")"

--- a/test/test_assembly_system.f90
+++ b/test/test_assembly_system.f90
@@ -5,7 +5,7 @@ program test_assembly_system
     implicit none
 
     write(*,*) "Testing finite element assembly system..."
-    
+
     call test_element_stiffness_matrix()
     call test_element_load_vector()
     call test_global_assembly()
@@ -14,7 +14,7 @@ program test_assembly_system
     call test_assembly_symmetry()
     call test_assembly_properties()
     call test_manufactured_assembly()
-    
+
     call check_summary("Assembly System")
 
 contains
@@ -28,23 +28,23 @@ contains
         type(function_t) :: f, uh
         type(dirichlet_bc_t) :: bc
         type(form_expr_t) :: a, L
-        
+
         ! Test on small mesh (but not too small)
-        mesh = unit_square_mesh(3)  ! 3x3 mesh has interior nodes
+        mesh = unit_square_mesh(3) ! 3x3 mesh has interior nodes
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Test that stiffness matrix produces reasonable results
         call check_condition(allocated(uh%values), &
             "Element stiffness: solution values allocated")
@@ -52,7 +52,7 @@ contains
             "Element stiffness: solution size matches DOFs")
         call check_condition(maxval(uh%values) > 0.0_dp, &
             "Element stiffness: positive solution values")
-        
+
         write(*,*) "   DOFs:", Vh%ndof
         write(*,*) "   Max solution:", maxval(uh%values)
         write(*,*) "   Min solution:", minval(uh%values)
@@ -68,14 +68,14 @@ contains
         type(dirichlet_bc_t) :: bc1, bc2
         type(form_expr_t) :: a1, a2, L1, L2
         real(dp) :: integral1, integral2, ratio
-        
+
         ! Test load vector scaling with mesh refinement
-        mesh1 = unit_square_mesh(3)  ! Coarse mesh
-        mesh2 = unit_square_mesh(5)  ! Fine mesh
-        
+        mesh1 = unit_square_mesh(3) ! Coarse mesh
+        mesh2 = unit_square_mesh(5) ! Fine mesh
+
         Vh1 = function_space(mesh1, "Lagrange", 1)
         Vh2 = function_space(mesh2, "Lagrange", 1)
-        
+
         ! Solve same problem on both meshes
         u1 = trial_function(Vh1)
         v1 = test_function(Vh1)
@@ -85,7 +85,7 @@ contains
         bc1 = dirichlet_bc(Vh1, 0.0_dp)
         uh1 = function(Vh1)
         call solve(a1 == L1, uh1, bc1)
-        
+
         u2 = trial_function(Vh2)
         v2 = test_function(Vh2)
         f2 = constant(1.0_dp)
@@ -94,14 +94,14 @@ contains
         bc2 = dirichlet_bc(Vh2, 0.0_dp)
         uh2 = function(Vh2)
         call solve(a2 == L2, uh2, bc2)
-        
+
         ! Compute approximate integrals (sum of values * approximate area per vertex)
         integral1 = sum(uh1%values) / real(Vh1%ndof, dp)
         integral2 = sum(uh2%values) / real(Vh2%ndof, dp)
-        
+
         call check_condition(integral2 > integral1, &
             "Load vector: finer mesh gives larger integral")
-        
+
         ! Ratio should be reasonable (not too different)
         ! Handle case where integral1 might be very small
         if (integral1 > 1.0e-10_dp) then
@@ -112,7 +112,7 @@ contains
             call check_condition(integral2 > 1.0e-6_dp, &
                 "Load vector: fine mesh gives positive integral")
         end if
-        
+
         write(*,*) "   Coarse mesh integral:", integral1
         write(*,*) "   Fine mesh integral:", integral2
         if (integral1 > 1.0e-10_dp) then
@@ -133,29 +133,29 @@ contains
         type(form_expr_t) :: a, L
         integer :: i, interior_count, boundary_count
         real(dp) :: sum_interior, sum_boundary
-        
+
         ! Test on small mesh to verify assembly
         mesh = unit_square_mesh(3)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Count interior vs boundary nodes and their contributions
         interior_count = 0
         boundary_count = 0
         sum_interior = 0.0_dp
         sum_boundary = 0.0_dp
-        
+
         do i = 1, Vh%ndof
             if (Vh%mesh%data%is_boundary_vertex(i)) then
                 boundary_count = boundary_count + 1
@@ -165,7 +165,7 @@ contains
                 sum_interior = sum_interior + uh%values(i)
             end if
         end do
-        
+
         call check_condition(interior_count > 0, &
             "Global assembly: found interior nodes")
         call check_condition(boundary_count > 0, &
@@ -174,7 +174,7 @@ contains
             "Global assembly: boundary values are zero")
         call check_condition(sum_interior > 0.0_dp, &
             "Global assembly: positive interior values")
-        
+
         write(*,*) "   Interior nodes:", interior_count
         write(*,*) "   Boundary nodes:", boundary_count
         write(*,*) "   Sum interior values:", sum_interior
@@ -191,56 +191,56 @@ contains
         real(dp) :: a11, a12, a21, a22, det_a
         logical :: all_positive_areas, reasonable_jacobians
         integer :: valid_elements
-        
+
         ! Test on regular mesh
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         all_positive_areas = .true.
         reasonable_jacobians = .true.
         valid_elements = 0
-        
+
         ! Check all triangles have positive area and reasonable Jacobians
         do e = 1, mesh%data%n_triangles
             v1 = mesh%data%triangles(1, e)
             v2 = mesh%data%triangles(2, e)
             v3 = mesh%data%triangles(3, e)
-            
+
             x1 = mesh%data%vertices(1, v1)
             y1 = mesh%data%vertices(2, v1)
             x2 = mesh%data%vertices(1, v2)
             y2 = mesh%data%vertices(2, v2)
             x3 = mesh%data%vertices(1, v3)
             y3 = mesh%data%vertices(2, v3)
-            
+
             ! Compute area using formula from assembly
             area_formula = 0.5_dp * abs((x2-x1)*(y3-y1) - (x3-x1)*(y2-y1))
-            
+
             ! Compute area using cross product
             area_computed = 0.5_dp * abs((x2-x1)*(y3-y1) - (y2-y1)*(x3-x1))
-            
+
             if (area_formula <= 0.0_dp) all_positive_areas = .false.
-            
+
             ! Check Jacobian matrix
             a11 = x2 - x1; a12 = x3 - x1
             a21 = y2 - y1; a22 = y3 - y1
             det_a = a11*a22 - a12*a21
-            
+
             if (abs(det_a) < 1.0e-12_dp) reasonable_jacobians = .false.
-            
+
             ! For unit square with regular mesh, areas should be similar
             if (area_formula > 1.0e-6_dp .and. area_formula < 1.0_dp) then
                 valid_elements = valid_elements + 1
             end if
         end do
-        
+
         call check_condition(all_positive_areas, &
             "Jacobian computation: all elements have positive area")
         call check_condition(reasonable_jacobians, &
             "Jacobian computation: all Jacobians are non-singular")
         call check_condition(valid_elements > 0, &
             "Jacobian computation: found valid elements")
-        
+
         write(*,*) "   Total triangles:", mesh%data%n_triangles
         write(*,*) "   Valid elements:", valid_elements
         write(*,*) "   All positive areas:", all_positive_areas
@@ -257,57 +257,57 @@ contains
         real(dp) :: grad_sum_x, grad_sum_y
         logical :: partition_of_unity
         integer :: test_element
-        
+
         ! Test on simple mesh
         mesh = unit_square_mesh(3)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Test gradient computation on first triangle
         test_element = 1
         v1 = mesh%data%triangles(1, test_element)
         v2 = mesh%data%triangles(2, test_element)
         v3 = mesh%data%triangles(3, test_element)
-        
+
         x1 = mesh%data%vertices(1, v1)
         y1 = mesh%data%vertices(2, v1)
         x2 = mesh%data%vertices(1, v2)
         y2 = mesh%data%vertices(2, v2)
         x3 = mesh%data%vertices(1, v3)
         y3 = mesh%data%vertices(2, v3)
-        
+
         ! Compute shape function gradients (copied from assembly code)
         a(1,1) = x2 - x1; a(1,2) = x3 - x1
         a(2,1) = y2 - y1; a(2,2) = y3 - y1
         det_a = a(1,1)*a(2,2) - a(1,2)*a(2,1)
-        
+
         ! Physical gradients
         b(1) = (-a(2,2) + a(2,1)) / det_a
         c(1) = ( a(1,2) - a(1,1)) / det_a
-        
+
         b(2) = a(2,2) / det_a
         c(2) = -a(1,2) / det_a
-        
+
         b(3) = -a(2,1) / det_a
         c(3) = a(1,1) / det_a
-        
+
         ! Test partition of unity: sum of gradients should be zero
         grad_sum_x = b(1) + b(2) + b(3)
         grad_sum_y = c(1) + c(2) + c(3)
-        
+
         partition_of_unity = (abs(grad_sum_x) < 1.0e-12_dp) .and. &
-                           (abs(grad_sum_y) < 1.0e-12_dp)
-        
+            (abs(grad_sum_y) < 1.0e-12_dp)
+
         call check_condition(partition_of_unity, &
             "Shape function derivatives: partition of unity")
         call check_condition(abs(det_a) > 1.0e-12_dp, &
             "Shape function derivatives: non-singular Jacobian")
-        
+
         ! Test that gradients are reasonable magnitudes
         call check_condition(maxval(abs(b)) < 100.0_dp, &
             "Shape function derivatives: reasonable x-gradients")
         call check_condition(maxval(abs(c)) < 100.0_dp, &
             "Shape function derivatives: reasonable y-gradients")
-        
+
         write(*,*) "   Test element:", test_element
         write(*,*) "   Jacobian determinant:", det_a
         write(*,*) "   Sum of x-gradients:", grad_sum_x
@@ -326,39 +326,39 @@ contains
         type(dirichlet_bc_t) :: bc1, bc2
         type(form_expr_t) :: a, L
         real(dp) :: energy1, energy2, diff
-        
+
         ! Test symmetry by solving with different BC values
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         ! Solve with BC = 0
         bc1 = dirichlet_bc(Vh, 0.0_dp)
         uh1 = function(Vh)
         call solve(a == L, uh1, bc1)
-        
+
         ! Solve with BC = 1
         bc2 = dirichlet_bc(Vh, 1.0_dp)
         uh2 = function(Vh)
         call solve(a == L, uh2, bc2)
-        
+
         ! Compute approximate energy norms (simplified)
         energy1 = sum(uh1%values**2)
         energy2 = sum(uh2%values**2)
-        
+
         call check_condition(energy1 >= 0.0_dp, &
             "Assembly symmetry: non-negative energy norm 1")
         call check_condition(energy2 >= 0.0_dp, &
             "Assembly symmetry: non-negative energy norm 2")
         call check_condition(energy2 > energy1, &
             "Assembly symmetry: higher BC gives higher energy")
-        
+
         write(*,*) "   Energy norm (BC=0):", energy1
         write(*,*) "   Energy norm (BC=1):", energy2
         write(*,*) "   Energy ratio:", energy2/energy1
@@ -375,42 +375,42 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: solution_norm, gradient_norm
         integer :: i
-        
+
         ! Test on medium mesh
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Compute solution norms
         solution_norm = sqrt(sum(uh%values**2))
-        
+
         ! Approximate gradient norm (very simplified)
         gradient_norm = 0.0_dp
         do i = 1, Vh%ndof-1
             gradient_norm = gradient_norm + (uh%values(i+1) - uh%values(i))**2
         end do
         gradient_norm = sqrt(gradient_norm)
-        
+
         call check_condition(solution_norm > 0.0_dp, &
             "Assembly properties: positive solution norm")
         call check_condition(gradient_norm >= 0.0_dp, &
             "Assembly properties: non-negative gradient norm")
-        
+
         ! Test coercivity: for Poisson, energy should be bounded
         call check_condition(solution_norm < 1.0_dp, &
             "Assembly properties: bounded solution")
-        
+
         write(*,*) "   Solution L2 norm:", solution_norm
         write(*,*) "   Approximate gradient norm:", gradient_norm
         write(*,*) "   DOFs:", Vh%ndof
@@ -428,40 +428,40 @@ contains
         real(dp) :: max_val, center_val, corner_val
         integer :: center_node, corner_node, i
         real(dp) :: x, y, min_dist_center, min_dist_corner, dist
-        
+
         ! Test assembly accuracy with known problem
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
-        f = constant(1.0_dp)  ! Note: solver hardcodes f=1
-        
+        f = constant(1.0_dp) ! Note: solver hardcodes f=1
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Find nodes closest to center and corner
         min_dist_center = huge(1.0_dp)
         min_dist_corner = huge(1.0_dp)
         center_node = 1
         corner_node = 1
-        
+
         do i = 1, Vh%ndof
             x = Vh%mesh%data%vertices(1, i)
             y = Vh%mesh%data%vertices(2, i)
-            
+
             ! Distance to center (0.5, 0.5)
             dist = (x - 0.5_dp)**2 + (y - 0.5_dp)**2
             if (dist < min_dist_center) then
                 min_dist_center = dist
                 center_node = i
             end if
-            
+
             ! Distance to corner (0, 0)
             dist = x**2 + y**2
             if (dist < min_dist_corner) then
@@ -469,11 +469,11 @@ contains
                 corner_node = i
             end if
         end do
-        
+
         max_val = maxval(uh%values)
         center_val = uh%values(center_node)
         corner_val = uh%values(corner_node)
-        
+
         ! For -Δu = 1 on unit square with u=0 on boundary:
         ! - Maximum should be at center
         ! - Corner should be zero (boundary)
@@ -485,7 +485,7 @@ contains
             "Manufactured assembly: reasonable center value")
         call check_condition(center_val < 0.15_dp, &
             "Manufactured assembly: bounded center value")
-        
+
         write(*,*) "   Maximum value:", max_val
         write(*,*) "   Center value:", center_val
         write(*,*) "   Corner value:", corner_val

--- a/test/test_boundary_conditions.f90
+++ b/test/test_boundary_conditions.f90
@@ -5,14 +5,14 @@ program test_boundary_conditions
     implicit none
 
     write(*,*) "Testing boundary condition implementation..."
-    
+
     call test_dirichlet_zero_bc()
     call test_dirichlet_nonzero_bc()
     call test_multiple_boundary_segments()
     call test_bc_consistency()
     call test_corner_node_handling()
     call test_manufactured_solution()
-    
+
     call check_summary("Boundary Conditions")
 
 contains
@@ -29,30 +29,30 @@ contains
         integer :: i
         real(dp) :: max_interior_value, min_boundary_value, max_boundary_value
         logical :: all_boundary_zero
-        
+
         ! Create simple mesh
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Define problem: -Δu = 1, u = 0 on boundary
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Check that boundary values are indeed zero
         all_boundary_zero = .true.
         max_boundary_value = -1.0e10_dp
         min_boundary_value = 1.0e10_dp
         max_interior_value = -1.0e10_dp
-        
+
         do i = 1, uh%space%ndof
             if (uh%space%mesh%data%is_boundary_vertex(i)) then
                 max_boundary_value = max(max_boundary_value, abs(uh%values(i)))
@@ -64,18 +64,18 @@ contains
                 max_interior_value = max(max_interior_value, uh%values(i))
             end if
         end do
-        
+
         call check_condition(all_boundary_zero, &
             "Zero Dirichlet BC: boundary values are zero")
         call check_condition(max_interior_value > 1.0e-6_dp, &
             "Zero Dirichlet BC: interior values are positive")
         call check_condition(max_boundary_value < 1.0e-10_dp, &
             "Zero Dirichlet BC: boundary tolerance check")
-        
+
         write(*,*) "   Max interior value:", max_interior_value
         write(*,*) "   Max boundary error:", max_boundary_value
         call plot(uh, filename="build/bc_zero_dirichlet_solution.png", &
-                  title="Zero Dirichlet BC solution")
+            title="Zero Dirichlet BC solution")
     end subroutine test_dirichlet_zero_bc
 
     ! Test non-zero Dirichlet BC
@@ -91,29 +91,29 @@ contains
         real(dp), parameter :: bc_value = 2.5_dp
         real(dp) :: max_error, error
         logical :: all_boundary_correct
-        
+
         ! Create mesh
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Note: Current implementation hardcodes f=1, so we test with that
         ! Define problem: -Δu = 1, u = 2.5 on boundary
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, bc_value)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Check boundary values
         all_boundary_correct = .true.
         max_error = 0.0_dp
-        
+
         do i = 1, uh%space%ndof
             if (uh%space%mesh%data%is_boundary_vertex(i)) then
                 error = abs(uh%values(i) - bc_value)
@@ -123,22 +123,22 @@ contains
                 end if
             end if
         end do
-        
+
         call check_condition(all_boundary_correct, &
             "Non-zero Dirichlet BC: boundary values correct")
         call check_condition(max_error < 1.0e-10_dp, &
             "Non-zero Dirichlet BC: boundary tolerance check")
-        
-        ! For -Δu = 1 with constant boundary conditions, 
+
+        ! For -Δu = 1 with constant boundary conditions,
         ! solution should have interior values > boundary values
         call check_condition(maxval(uh%values) > minval(uh%values), &
             "Poisson equation: interior values > boundary values")
-        
+
         write(*,*) "   BC value:", bc_value
         write(*,*) "   Max boundary error:", max_error
         write(*,*) "   Solution range:", minval(uh%values), "to", maxval(uh%values)
         call plot(uh, filename="build/bc_nonzero_dirichlet_solution.png", &
-                  title="Non-zero Dirichlet BC solution")
+            title="Non-zero Dirichlet BC solution")
     end subroutine test_dirichlet_nonzero_bc
 
     ! Test boundary condition identification on different segments
@@ -148,27 +148,27 @@ contains
         integer :: i, boundary_count, total_vertices
         real(dp) :: x, y
         logical :: has_left_boundary, has_right_boundary, has_top_boundary, has_bottom_boundary
-        
+
         ! Create mesh
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         boundary_count = 0
         total_vertices = Vh%mesh%data%n_vertices
         has_left_boundary = .false.
         has_right_boundary = .false.
         has_top_boundary = .false.
         has_bottom_boundary = .false.
-        
+
         ! Check boundary vertex identification
         do i = 1, total_vertices
             if (Vh%mesh%data%is_boundary_vertex(i)) then
                 boundary_count = boundary_count + 1
-                
+
                 ! Get vertex coordinates
                 x = Vh%mesh%data%vertices(1, i)
                 y = Vh%mesh%data%vertices(2, i)
-                
+
                 ! Check which boundary segment this vertex belongs to
                 if (abs(x - 0.0_dp) < 1.0e-10_dp) has_left_boundary = .true.
                 if (abs(x - 1.0_dp) < 1.0e-10_dp) has_right_boundary = .true.
@@ -176,7 +176,7 @@ contains
                 if (abs(y - 1.0_dp) < 1.0e-10_dp) has_top_boundary = .true.
             end if
         end do
-        
+
         call check_condition(boundary_count > 0, &
             "Boundary detection: found boundary vertices")
         call check_condition(has_left_boundary, &
@@ -187,12 +187,12 @@ contains
             "Boundary detection: found top boundary vertices")
         call check_condition(has_bottom_boundary, &
             "Boundary detection: found bottom boundary vertices")
-        
+
         ! Boundary should be a reasonable fraction of total vertices
         ! For structured meshes, this can be high (e.g., 6x6 grid has 24 boundary vs 16 interior)
         call check_condition(real(boundary_count, dp) / real(total_vertices, dp) < 0.8_dp, &
             "Boundary detection: reasonable boundary/interior ratio")
-        
+
         write(*,*) "   Total vertices:", total_vertices
         write(*,*) "   Boundary vertices:", boundary_count
         write(*,*) "   Boundary fraction:", real(boundary_count, dp) / real(total_vertices, dp)
@@ -210,40 +210,40 @@ contains
         integer :: i
         real(dp) :: max_diff
         logical :: solutions_different
-        
+
         ! Create mesh
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Define same problem with different BC values
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         ! Solve with BC = 0
         bc1 = dirichlet_bc(Vh, 0.0_dp)
         uh1 = function(Vh)
         call solve(a == L, uh1, bc1)
-        
+
         ! Solve with BC = 1
         bc2 = dirichlet_bc(Vh, 1.0_dp)
         uh2 = function(Vh)
         call solve(a == L, uh2, bc2)
-        
+
         ! Solutions should be different
         max_diff = 0.0_dp
         do i = 1, uh1%space%ndof
             max_diff = max(max_diff, abs(uh1%values(i) - uh2%values(i)))
         end do
-        
+
         solutions_different = max_diff > 1.0e-6_dp
-        
+
         call check_condition(solutions_different, &
             "BC consistency: different BCs give different solutions")
-        
+
         write(*,*) "   Max difference between BC=0 and BC=1 solutions:", max_diff
     end subroutine test_bc_consistency
 
@@ -253,46 +253,46 @@ contains
         type(function_space_t) :: Vh
         integer :: i, corner_count
         real(dp) :: x, y
-        logical :: found_corners(4)  ! [bottom-left, bottom-right, top-left, top-right]
-        
+        logical :: found_corners(4) ! [bottom-left, bottom-right, top-left, top-right]
+
         ! Create mesh
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         corner_count = 0
         found_corners = .false.
-        
+
         ! Check for corner vertices
         do i = 1, Vh%mesh%data%n_vertices
             if (Vh%mesh%data%is_boundary_vertex(i)) then
                 x = Vh%mesh%data%vertices(1, i)
                 y = Vh%mesh%data%vertices(2, i)
-                
+
                 ! Check for corners
                 if (abs(x - 0.0_dp) < 1.0e-10_dp .and. abs(y - 0.0_dp) < 1.0e-10_dp) then
-                    found_corners(1) = .true.  ! bottom-left
+                    found_corners(1) = .true. ! bottom-left
                     corner_count = corner_count + 1
                 end if
                 if (abs(x - 1.0_dp) < 1.0e-10_dp .and. abs(y - 0.0_dp) < 1.0e-10_dp) then
-                    found_corners(2) = .true.  ! bottom-right
+                    found_corners(2) = .true. ! bottom-right
                     corner_count = corner_count + 1
                 end if
                 if (abs(x - 0.0_dp) < 1.0e-10_dp .and. abs(y - 1.0_dp) < 1.0e-10_dp) then
-                    found_corners(3) = .true.  ! top-left
+                    found_corners(3) = .true. ! top-left
                     corner_count = corner_count + 1
                 end if
                 if (abs(x - 1.0_dp) < 1.0e-10_dp .and. abs(y - 1.0_dp) < 1.0e-10_dp) then
-                    found_corners(4) = .true.  ! top-right
+                    found_corners(4) = .true. ! top-right
                     corner_count = corner_count + 1
                 end if
             end if
         end do
-        
+
         call check_condition(corner_count == 4, &
             "Corner detection: found all 4 corners")
         call check_condition(all(found_corners), &
             "Corner detection: all corners identified as boundary")
-        
+
         write(*,*) "   Found corners:", corner_count
         write(*,*) "   Corner flags:", found_corners
     end subroutine test_corner_node_handling
@@ -309,39 +309,39 @@ contains
         integer :: i
         real(dp) :: x, y, u_exact, max_error, l2_error
         real(dp) :: total_area, elem_area
-        
+
         ! Create fine mesh for accuracy
         mesh = unit_square_mesh(8)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Since current implementation hardcodes f=1, we test with that
         ! For -Δu = 1 with u=0 on boundary, we expect a bowl-shaped solution
         ! with maximum around 0.1 at center for unit square
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
-        f = constant(1.0_dp)  ! Note: solver ignores this and uses f=1
-        
+        f = constant(1.0_dp) ! Note: solver ignores this and uses f=1
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Test basic properties of the solution
         max_error = maxval(uh%values)
-        
+
         ! For -Δu = 1 on unit square with u=0 on boundary:
         ! - All boundary values should be 0
-        ! - All interior values should be positive  
+        ! - All interior values should be positive
         ! - Maximum should be around 0.1 at center
         call check_condition(max_error > 0.01_dp, &
             "Poisson solution: positive interior values")
         call check_condition(max_error < 0.15_dp, &
             "Poisson solution: reasonable maximum value")
-        
+
         ! Check that boundary values are indeed zero
         l2_error = 0.0_dp
         do i = 1, uh%space%ndof
@@ -349,15 +349,15 @@ contains
                 l2_error = max(l2_error, abs(uh%values(i)))
             end if
         end do
-        
+
         call check_condition(l2_error < 1.0e-10_dp, &
             "Poisson solution: boundary values are zero")
-        
+
         write(*,*) "   Max solution value:", max_error
         write(*,*) "   Max boundary error:", l2_error
         write(*,*) "   Mesh resolution: 8x8"
         call plot(uh, filename="build/bc_manufactured_solution.png", &
-                  title="Manufactured Poisson solution")
+            title="Manufactured Poisson solution")
     end subroutine test_manufactured_solution
 
 end program test_boundary_conditions

--- a/test/test_boundary_conditions_advanced.f90
+++ b/test/test_boundary_conditions_advanced.f90
@@ -5,13 +5,13 @@ program test_boundary_conditions_advanced
     implicit none
 
     write(*,*) "Testing advanced boundary condition scenarios..."
-    
+
     call test_mixed_bc_different_segments()
     call test_bc_on_refined_mesh()
     call test_bc_matrix_modification()
     call test_bc_corner_constraints()
     call test_bc_convergence_study()
-    
+
     call check_summary("Advanced Boundary Conditions")
 
 contains
@@ -22,39 +22,39 @@ contains
         type(function_space_t) :: Vh
         integer :: i, left_count, right_count, top_count, bottom_count
         real(dp) :: x, y
-        
+
         ! Create mesh
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         left_count = 0
         right_count = 0
         top_count = 0
         bottom_count = 0
-        
+
         ! Count vertices on each boundary segment
         do i = 1, Vh%mesh%data%n_vertices
             if (Vh%mesh%data%is_boundary_vertex(i)) then
                 x = Vh%mesh%data%vertices(1, i)
                 y = Vh%mesh%data%vertices(2, i)
-                
+
                 if (abs(x - 0.0_dp) < 1.0e-10_dp) left_count = left_count + 1
                 if (abs(x - 1.0_dp) < 1.0e-10_dp) right_count = right_count + 1
                 if (abs(y - 0.0_dp) < 1.0e-10_dp) bottom_count = bottom_count + 1
                 if (abs(y - 1.0_dp) < 1.0e-10_dp) top_count = top_count + 1
             end if
         end do
-        
+
         call check_condition(left_count > 0 .and. right_count > 0 .and. &
-                           top_count > 0 .and. bottom_count > 0, &
+            top_count > 0 .and. bottom_count > 0, &
             "Mixed BC segments: all boundary segments have vertices")
-        
+
         ! Test that each segment has reasonable number of vertices
         call check_condition(left_count >= 5 .and. left_count <= 10, &
             "Mixed BC segments: left boundary has reasonable vertex count")
         call check_condition(right_count >= 5 .and. right_count <= 10, &
             "Mixed BC segments: right boundary has reasonable vertex count")
-        
+
         write(*,*) "   Left boundary vertices:", left_count
         write(*,*) "   Right boundary vertices:", right_count
         write(*,*) "   Top boundary vertices:", top_count
@@ -71,52 +71,52 @@ contains
         type(dirichlet_bc_t) :: bc_coarse, bc_fine
         type(form_expr_t) :: a_coarse, a_fine, L_coarse, L_fine
         real(dp) :: max_coarse, max_fine
-        
+
         ! Test on coarse mesh
         mesh_coarse = unit_square_mesh(4)
         Vh_coarse = function_space(mesh_coarse, "Lagrange", 1)
-        
+
         u_coarse = trial_function(Vh_coarse)
         v_coarse = test_function(Vh_coarse)
         f_coarse = constant(1.0_dp)
-        
+
         a_coarse = inner(grad(u_coarse), grad(v_coarse))*dx
         L_coarse = f_coarse*v_coarse*dx
-        
+
         bc_coarse = dirichlet_bc(Vh_coarse, 0.0_dp)
         uh_coarse = function(Vh_coarse)
-        
+
         call solve(a_coarse == L_coarse, uh_coarse, bc_coarse)
         max_coarse = maxval(uh_coarse%values)
-        
+
         ! Test on fine mesh
         mesh_fine = unit_square_mesh(8)
         Vh_fine = function_space(mesh_fine, "Lagrange", 1)
-        
+
         u_fine = trial_function(Vh_fine)
         v_fine = test_function(Vh_fine)
         f_fine = constant(1.0_dp)
-        
+
         a_fine = inner(grad(u_fine), grad(v_fine))*dx
         L_fine = f_fine*v_fine*dx
-        
+
         bc_fine = dirichlet_bc(Vh_fine, 0.0_dp)
         uh_fine = function(Vh_fine)
-        
+
         call solve(a_fine == L_fine, uh_fine, bc_fine)
         max_fine = maxval(uh_fine%values)
-        
+
         ! Fine mesh should give more accurate solution (higher maximum)
         call check_condition(max_fine > max_coarse, &
             "Refined mesh: finer mesh gives more accurate solution")
         call check_condition(abs(max_fine - max_coarse) / max_coarse < 0.5_dp, &
             "Refined mesh: solutions are reasonably close")
-        
+
         write(*,*) "   Coarse mesh (4x4) max:", max_coarse
         write(*,*) "   Fine mesh (8x8) max:", max_fine
         write(*,*) "   Relative difference:", abs(max_fine - max_coarse) / max_coarse
         call plot(uh_fine, filename="build/bc_refined_mesh_solution.png", &
-                  title="Refined mesh BC solution (8x8)")
+            title="Refined mesh BC solution (8x8)")
     end subroutine test_bc_on_refined_mesh
 
     ! Test that BC modification properly zeroes matrix rows and sets diagonal
@@ -128,12 +128,12 @@ contains
         type(dirichlet_bc_t) :: bc
         real(dp), allocatable :: K(:,:), F(:)
         real(dp) :: max_offdiag, tol, bc_value
-        
+
         ! Create small mesh for testing
         mesh = unit_square_mesh(3)
         Vh = function_space(mesh, "Lagrange", 1)
         ndof = Vh%ndof
-        
+
         ! Find a boundary node
         boundary_node = -1
         do i = 1, ndof
@@ -142,20 +142,20 @@ contains
                 exit
             end if
         end do
-        
+
         found_boundary_node = boundary_node > 0
         call check_condition(found_boundary_node, &
             "Matrix modification: found boundary node for testing")
-        
+
         if (found_boundary_node) then
             write(*,*) "   Testing with boundary node:", boundary_node
             write(*,*) "   Total DOFs:", ndof
-            
+
             ! Assemble Laplacian system and inspect modified matrix row
             bc_value = 2.0_dp
             bc = dirichlet_bc(Vh, bc_value)
             call assemble_laplacian_system(Vh, bc, K, F)
-            
+
             tol = 1.0e-10_dp
             max_offdiag = 0.0_dp
             do j = 1, ndof
@@ -164,17 +164,17 @@ contains
             end do
             row_zeroed = max_offdiag < tol
             diagonal_is_one = abs(K(boundary_node, boundary_node) - 1.0_dp) < tol
-            
+
             call check_condition(row_zeroed, &
                 "Matrix modification: boundary row off-diagonals zeroed")
             call check_condition(diagonal_is_one, &
                 "Matrix modification: boundary diagonal set to one")
             call check_condition(abs(F(boundary_node) - bc_value) < tol, &
                 "Matrix modification: RHS matches BC value")
-            
+
             deallocate(K, F)
         end if
-        
+
     end subroutine test_bc_matrix_modification
 
     ! Test corner node constraints (nodes that belong to multiple boundaries)
@@ -189,31 +189,31 @@ contains
         integer :: i, corner_node
         real(dp) :: x, y, corner_value
         logical :: found_corner
-        
+
         ! Create mesh
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Solve problem
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 1.5_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Find a corner node and check its value
         found_corner = .false.
         do i = 1, Vh%ndof
             if (Vh%mesh%data%is_boundary_vertex(i)) then
                 x = Vh%mesh%data%vertices(1, i)
                 y = Vh%mesh%data%vertices(2, i)
-                
+
                 ! Check for bottom-left corner
                 if (abs(x - 0.0_dp) < 1.0e-10_dp .and. abs(y - 0.0_dp) < 1.0e-10_dp) then
                     corner_node = i
@@ -223,10 +223,10 @@ contains
                 end if
             end if
         end do
-        
+
         call check_condition(found_corner, &
             "Corner constraints: found corner node")
-        
+
         if (found_corner) then
             call check_condition(abs(corner_value - 1.5_dp) < 1.0e-12_dp, &
                 "Corner constraints: corner value matches BC")
@@ -247,71 +247,71 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: max_val_4, max_val_8, max_val_16
         real(dp) :: conv_rate_1, conv_rate_2
-        
+
         ! Test on 4x4 mesh
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
         max_val_4 = maxval(uh%values)
-        
+
         ! Test on 8x8 mesh
         mesh = unit_square_mesh(8)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
         max_val_8 = maxval(uh%values)
-        
+
         ! Test on 16x16 mesh
         mesh = unit_square_mesh(16)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
         max_val_16 = maxval(uh%values)
-        
+
         ! Check convergence: values should increase and converge
         call check_condition(max_val_8 > max_val_4, &
             "Convergence: 8x8 mesh gives higher maximum than 4x4")
         call check_condition(max_val_16 > max_val_8, &
             "Convergence: 16x16 mesh gives higher maximum than 8x8")
-        
+
         ! Check that convergence is slowing down (approaching limit)
         conv_rate_1 = (max_val_8 - max_val_4) / max_val_4
         conv_rate_2 = (max_val_16 - max_val_8) / max_val_8
-        
+
         call check_condition(conv_rate_2 < conv_rate_1, &
             "Convergence: convergence rate is decreasing")
-        
+
         write(*,*) "   Max value 4x4:", max_val_4
         write(*,*) "   Max value 8x8:", max_val_8
         write(*,*) "   Max value 16x16:", max_val_16

--- a/test/test_clean_mesh_api.f90
+++ b/test/test_clean_mesh_api.f90
@@ -5,39 +5,39 @@ program test_clean_mesh_api
 
     type(mesh_t) :: mesh
     type(boundary_t) :: boundary, outer, hole
-    
+
     write(*,*) "=== Testing Clean Mesh Generation API ==="
     write(*,*) ""
-    
+
     ! Simple built-ins
     write(*,*) "1. Simple built-ins:"
     mesh = unit_square_mesh(20)
     write(*,*) "   ✓ unit_square_mesh(20)"
-    
+
     mesh = rectangle_mesh(20, 30, [0.0_dp, 2.0_dp, 0.0_dp, 1.5_dp])
     write(*,*) "   ✓ rectangle_mesh(20, 30, [0,2,0,1.5])"
-    
+
     mesh = unit_disk_mesh(resolution=0.1_dp)
     write(*,*) "   ✓ unit_disk_mesh(resolution=0.1)"
-    
+
     ! Boundary-based
     write(*,*) ""
     write(*,*) "2. Boundary-based generation:"
     boundary = circle_boundary([0.5_dp, 0.5_dp], 0.3_dp, 20)
     write(*,*) "   ✓ circle_boundary(center, radius, n)"
-    
+
     boundary = rectangle_boundary([0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp], 40)
     write(*,*) "   ✓ rectangle_boundary(domain, n)"
-    
+
     boundary = l_shape_boundary(1.0_dp, 30)
     write(*,*) "   ✓ l_shape_boundary(size, n)"
-    
+
     ! Mesh from boundary
     write(*,*) ""
     write(*,*) "3. Mesh from boundary:"
     mesh = mesh_from_boundary(boundary, resolution=0.05_dp)
     write(*,*) "   ✓ mesh_from_boundary(boundary, resolution)"
-    
+
     write(*,*) ""
     write(*,*) "=== Clean Mesh API Ready! ==="
     write(*,*) ""
@@ -46,7 +46,7 @@ program test_clean_mesh_api
     write(*,*) "• rectangle_mesh(nx, ny, [x0,x1,y0,y1])"
     write(*,*) "• unit_disk_mesh(resolution=h)"
     write(*,*) "• circle_boundary(center, radius, n)"
-    write(*,*) "• rectangle_boundary(domain, n)"  
+    write(*,*) "• rectangle_boundary(domain, n)"
     write(*,*) "• line_segment(p1, p2, n)"
     write(*,*) "• arc_segment(p1, p2, center, n)"
     write(*,*) "• l_shape_boundary(size, n)"

--- a/test/test_debug_location.f90
+++ b/test/test_debug_location.f90
@@ -31,7 +31,7 @@ program test_debug_location
     do t = 1, mesh%ntriangles
         if (mesh%triangles(t)%valid) then
             print *, "Triangle", t, "vertices:", mesh%triangles(t)%vertices,     &
-                     "neighbors:", mesh%triangles(t)%neighbors
+                "neighbors:", mesh%triangles(t)%neighbors
             do e = 1, 3
                 if (mesh%triangles(t)%neighbors(e) /= 0) then
                     total_neighbors = total_neighbors + 1

--- a/test/test_debug_refinement.f90
+++ b/test/test_debug_refinement.f90
@@ -37,7 +37,7 @@ program test_debug_refinement
     write(*,*) "--- Investigating incircle issue ---"
 
     call constrained_delaunay_triangulate(points, segments, mesh,             &
-                                          final_segments=cdt_segments)
+        final_segments=cdt_segments)
     write(*,'(A,I5)') " After CDT: npoints =", mesh%npoints
     write(*,'(A,I5)') " After CDT: ntriangles =", mesh%ntriangles
     write(*,'(A,L5)') " Robust mode after CDT:", is_robust_mode()

--- a/test/test_delaunay_triangulation.f90
+++ b/test/test_delaunay_triangulation.f90
@@ -2,22 +2,22 @@ program test_delaunay_triangulation
     use fortfem_kinds, only: dp
     use triangulator, only: triangulate_points
     use triangulation_fortran, only: triangulation_result_t, triangulate_fortran, &
-                                     cleanup_triangulation
+        cleanup_triangulation
     use delaunay_types, only: point_t
     use geometric_predicates, only: orientation, ORIENTATION_CCW, ORIENTATION_CW
     implicit none
-    
+
     integer :: test_count = 0, passed_tests = 0
-    
+
     write(*,*) "=== FortFEM Delaunay Triangulation Tests ==="
     write(*,*) ""
-    
+
     ! Test sequence following TDD
     call test_simple_triangle_vertices()
     call test_square_triangulation()
     call test_unit_circle_points()
     call test_boundary_constraint_preservation()
-    
+
     ! Summary
     write(*,*) ""
     write(*,'(A,I0,A,I0)') "Tests passed: ", passed_tests, "/", test_count
@@ -27,7 +27,7 @@ program test_delaunay_triangulation
         write(*,*) "✗ Some tests failed!"
         stop 1
     end if
-    
+
 contains
 
     subroutine test_simple_triangle_vertices()
@@ -40,32 +40,32 @@ contains
         integer, allocatable :: mesh_triangles(:,:)
         integer :: n_points, n_triangles
         integer :: tri(3)
-        
+
         call start_test(test_name)
-        
+
         ! This test validates we can create basic triangle from 3 points
         ! Expected: 1 triangle with vertices 1,2,3
         write(*,*) "  Input: 3 points forming equilateral triangle"
         write(*,*) "  Expected: 1 triangle, all points preserved"
-        
+
         ! Test actual triangulation
         call triangulate_points(points, mesh_points, mesh_triangles, &
-                                n_points, n_triangles)
-        
+            n_points, n_triangles)
+
         write(*,*) "  Output vertices:", n_points
         write(*,*) "  Output triangles:", n_triangles
-        
+
         call assert_equal_int(n_points, 3, "Simple triangle: 3 vertices")
         call assert_equal_int(n_triangles, 1, "Simple triangle: 1 triangle")
-        
+
         tri = mesh_triangles(:, 1)
         call assert_true(all(tri >= 1 .and. tri <= 3), &
             "Simple triangle: triangle uses input vertices")
-        
+
         deallocate(mesh_points, mesh_triangles)
         call end_test()
     end subroutine
-    
+
     subroutine test_square_triangulation()
         character(len=*), parameter :: test_name = "Unit Square Triangulation"
         real(dp), parameter :: points(2,4) = reshape([&
@@ -79,20 +79,20 @@ contains
             3, 4, &
             4, 1], [2, 4])
         type(triangulation_result_t) :: result
-        
+
         call start_test(test_name)
-        
+
         ! This test validates square is properly triangulated
         ! Expected: 2 triangles forming the square
         write(*,*) "  Input: 4 corner points of unit square"
         write(*,*) "  Expected: 2 triangles, Delaunay property satisfied"
-        
+
         call triangulate_fortran(points, segments, result)
-        
+
         write(*,*) "  Output points:", result%npoints
         write(*,*) "  Output triangles:", result%ntriangles
         write(*,*) "  Output segments:", result%nsegments
-        
+
         call assert_equal_int(result%npoints, 4, "Unit square: 4 vertices")
         call assert_equal_int(result%nsegments, 4, "Unit square: 4 boundary segments")
         call assert_true(result%ntriangles >= 1, "Unit square: at least one triangle")
@@ -100,11 +100,11 @@ contains
             "Unit square: triangles have positive area")
         call assert_true(no_edge_self_intersections(result), &
             "Unit square: triangulation edges do not intersect")
-        
+
         call cleanup_triangulation(result)
         call end_test()
     end subroutine
-    
+
     subroutine test_unit_circle_points()
         character(len=*), parameter :: test_name = "Unit Circle Boundary Points"
         integer, parameter :: n = 8
@@ -113,33 +113,33 @@ contains
         integer, allocatable :: mesh_triangles(:,:)
         integer :: i, n_points, n_triangles
         real(dp) :: theta
-        
+
         call start_test(test_name)
-        
+
         ! Generate 8 points on unit circle
         do i = 1, n
             theta = 2.0_dp * acos(-1.0_dp) * (i-1) / n
             points(1, i) = cos(theta)
             points(2, i) = sin(theta)
         end do
-        
+
         write(*,*) "  Input: 8 points on unit circle boundary"
         write(*,*) "  Expected: Triangulation with boundary preserved"
-        
+
         call triangulate_points(points, mesh_points, mesh_triangles, &
-                                n_points, n_triangles)
-        
+            n_points, n_triangles)
+
         write(*,*) "  Output vertices:", n_points
         write(*,*) "  Output triangles:", n_triangles
-        
+
         call assert_true(n_points >= n, "Unit circle: vertices preserved or refined")
         call assert_true(n_triangles > 0, "Unit circle: triangles created")
-        
+
         deallocate(mesh_points, mesh_triangles)
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_boundary_constraint_preservation()
         character(len=*), parameter :: test_name = "Boundary Constraint Preservation"
         real(dp), parameter :: points(2,4) = reshape([&
@@ -153,31 +153,31 @@ contains
             3, 4, &
             4, 1], [2, 4])
         type(triangulation_result_t) :: result
-        
+
         call start_test(test_name)
-        
+
         write(*,*) "  Input: Square with constrained boundary edges"
         write(*,*) "  Expected: Boundary edges preserved in triangulation"
-        
+
         call triangulate_fortran(points, edges, result)
-        
+
         call assert_true(constraint_edges_preserved(result, edges), &
             "Boundary constraints: all boundary edges preserved")
         call assert_true(no_edge_self_intersections(result), &
             "Boundary constraints: triangulation edges do not intersect")
-        
+
         call cleanup_triangulation(result)
-        
+
         call end_test()
     end subroutine
-    
+
     ! Test framework helpers
     subroutine start_test(test_name)
         character(len=*), intent(in) :: test_name
         test_count = test_count + 1
         write(*,'(A,I0,A,A)') "Test ", test_count, ": ", test_name
     end subroutine
-    
+
     subroutine end_test()
         passed_tests = passed_tests + 1
         write(*,*) "  ✓ PASSED"
@@ -192,7 +192,7 @@ contains
             stop 1
         end if
     end subroutine assert_equal_int
-    
+
     subroutine assert_true(condition, description)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: description
@@ -201,12 +201,12 @@ contains
             stop 1
         end if
     end subroutine assert_true
-    
+
     logical function all_triangles_positive(result)
         type(triangulation_result_t), intent(in) :: result
         integer :: i
         real(dp) :: x1, y1, x2, y2, x3, y3, area
-        
+
         all_triangles_positive = .true.
         do i = 1, result%ntriangles
             x1 = result%points(1, result%triangles(1, i))
@@ -215,7 +215,7 @@ contains
             y2 = result%points(2, result%triangles(2, i))
             x3 = result%points(1, result%triangles(3, i))
             y3 = result%points(2, result%triangles(3, i))
-            
+
             area = 0.5_dp * ((x1*(y2-y3) + x2*(y3-y1) + x3*(y1-y2)))
             if (area <= 0.0_dp) then
                 all_triangles_positive = .false.
@@ -223,7 +223,7 @@ contains
             end if
         end do
     end function all_triangles_positive
-    
+
     logical function no_edge_self_intersections(result)
         type(triangulation_result_t), intent(in) :: result
         integer :: ntri, max_edges, ecount
@@ -231,12 +231,12 @@ contains
         integer :: t, k, i, j
         integer :: v1, v2, w1, w2, tmp
         logical :: duplicate
-        
+
         ntri = result%ntriangles
         max_edges = 3 * ntri
         allocate(edges(2, max_edges))
         ecount = 0
-        
+
         ! Collect unique undirected edges from triangles
         do t = 1, ntri
             do k = 1, 3
@@ -248,7 +248,7 @@ contains
                     v1 = v2
                     v2 = tmp
                 end if
-                
+
                 duplicate = .false.
                 do i = 1, ecount
                     if (edges(1, i) == v1 .and. edges(2, i) == v2) then
@@ -256,7 +256,7 @@ contains
                         exit
                     end if
                 end do
-                
+
                 if (.not. duplicate) then
                     ecount = ecount + 1
                     edges(1, ecount) = v1
@@ -264,9 +264,9 @@ contains
                 end if
             end do
         end do
-        
+
         no_edge_self_intersections = .true.
-        
+
         ! Check pairwise edge intersections, ignoring shared endpoints
         do i = 1, ecount - 1
             do j = i + 1, ecount
@@ -274,9 +274,9 @@ contains
                 v2 = edges(2, i)
                 w1 = edges(1, j)
                 w2 = edges(2, j)
-                
+
                 if (v1 == w1 .or. v1 == w2 .or. v2 == w1 .or. v2 == w2) cycle
-                
+
                 if (segments_intersect_strict(result, v1, v2, w1, w2)) then
                     no_edge_self_intersections = .false.
                     exit
@@ -284,16 +284,16 @@ contains
             end do
             if (.not. no_edge_self_intersections) exit
         end do
-        
+
         deallocate(edges)
     end function no_edge_self_intersections
-    
+
     logical function segments_intersect_strict(result, a1, a2, b1, b2)
         type(triangulation_result_t), intent(in) :: result
         integer, intent(in) :: a1, a2, b1, b2
         type(point_t) :: p1, p2, q1, q2
         integer :: o1, o2, o3, o4
-        
+
         p1%x = result%points(1, a1)
         p1%y = result%points(2, a1)
         p2%x = result%points(1, a2)
@@ -302,38 +302,38 @@ contains
         q1%y = result%points(2, b1)
         q2%x = result%points(1, b2)
         q2%y = result%points(2, b2)
-        
+
         o1 = orientation(p1, p2, q1)
         o2 = orientation(p1, p2, q2)
         o3 = orientation(q1, q2, p1)
         o4 = orientation(q1, q2, p2)
-        
+
         if (o1 /= o2 .and. o3 /= o4) then
             segments_intersect_strict = .true.
         else
             segments_intersect_strict = .false.
         end if
     end function segments_intersect_strict
-    
+
     logical function constraint_edges_preserved(result, edges)
         type(triangulation_result_t), intent(in) :: result
         integer, intent(in) :: edges(:,:)
         integer :: e, t
         integer :: v1, v2, a, b, c
         logical :: found
-        
+
         constraint_edges_preserved = .true.
-        
+
         do e = 1, size(edges, 2)
             v1 = edges(1, e)
             v2 = edges(2, e)
             found = .false.
-            
+
             do t = 1, result%ntriangles
                 a = result%triangles(1, t)
                 b = result%triangles(2, t)
                 c = result%triangles(3, t)
-                
+
                 if ((a == v1 .and. b == v2) .or. (a == v2 .and. b == v1) .or. &
                     (b == v1 .and. c == v2) .or. (b == v2 .and. c == v1) .or. &
                     (c == v1 .and. a == v2) .or. (c == v2 .and. a == v1)) then
@@ -341,7 +341,7 @@ contains
                     exit
                 end if
             end do
-            
+
             if (.not. found) then
                 constraint_edges_preserved = .false.
                 return

--- a/test/test_detailed_diagnostic.f90
+++ b/test/test_detailed_diagnostic.f90
@@ -8,37 +8,37 @@ program test_detailed_diagnostic
     type(mesh_t) :: mesh
     real(dp) :: points(2, 3)
     integer :: i, super_tri_idx, point_idx
-    
+
     write(*,*) "=== Detailed Bowyer-Watson Diagnostic ==="
-    
+
     ! Create simple triangle: (0,0), (1,0), (0.5,1)
     points(:, 1) = [0.0_dp, 0.0_dp]
     points(:, 2) = [1.0_dp, 0.0_dp]
     points(:, 3) = [0.5_dp, 1.0_dp]
-    
+
     ! Initialize mesh with appropriate size
     call create_mesh(mesh, size(points, 2) + 3, 6 * size(points, 2), 3 * size(points, 2))
-    
+
     ! Create super-triangle containing all points
     call create_super_triangle(points, mesh, super_tri_idx)
-    
+
     ! Add input points to mesh
     do i = 1, size(points, 2)
         point_idx = add_point(mesh, points(1, i), points(2, i), i)
     end do
-    
+
     ! Insert each point using Bowyer-Watson algorithm
-    do i = 4, mesh%npoints  ! Start after super-triangle vertices
+    do i = 4, mesh%npoints ! Start after super-triangle vertices
         call insert_point(mesh, i)
     end do
-    
+
     ! DON'T remove super-triangle for debugging
     ! call remove_super_triangle(mesh)
-    
+
     write(*,*) "After Delaunay triangulation:"
     write(*,*) "  Vertices:", mesh%npoints
     write(*,*) "  Triangles:", mesh%ntriangles
-    
+
     write(*,*) "All triangles (before super-triangle removal):"
     do i = 1, mesh%ntriangles
         if (mesh%triangles(i)%valid) then
@@ -51,7 +51,7 @@ program test_detailed_diagnostic
             write(*,'(A,I0,A)') "  Triangle ", i, ": [invalid]"
         end if
     end do
-    
+
     write(*,*) "Super-triangle vertices:", mesh%super_vertices
 
 end program test_detailed_diagnostic

--- a/test/test_fortfem_api_solvers_modules.f90
+++ b/test/test_fortfem_api_solvers_modules.f90
@@ -51,7 +51,7 @@ contains
         u = function(Vh)
         bc = dirichlet_bc(Vh, 0.0_dp)
         call solve_laplacian_problem(u, bc, solver_options(method="auto"), &
-                                     stats)
+            stats)
 
         call check_condition(allocated(u%values), &
             "Laplacian module: solution values allocated")
@@ -72,7 +72,7 @@ contains
         bc = dirichlet_bc(Vh, 0.0_dp)
 
         call solve_laplacian_problem_p2(u, bc, solver_options(method="auto"), &
-                                        stats)
+            stats)
 
         max_value = maxval(abs(u%values))
         call check_condition(allocated(u%values), &
@@ -101,7 +101,7 @@ contains
         bc_vec = vector_bc(Vh_vec, [0.0_dp, 0.0_dp])
 
         opts = solver_options(method="gmres", tolerance=1.0e-6_dp, &
-                              max_iterations=50, restart=10)
+            max_iterations=50, restart=10)
 
         call solve_curl_curl_problem(Eh, bc_vec, "direct", opts, stats)
 

--- a/test/test_freefem_benchmark.f90
+++ b/test/test_freefem_benchmark.f90
@@ -5,14 +5,14 @@ program test_freefem_benchmark
     implicit none
 
     integer :: test_count = 0, passed_tests = 0
-    
+
     write(*,*) "=== FreeFEM Benchmark TDD Tests ==="
     write(*,*) ""
-    
+
     call test_benchmark_setup()
     call test_mesh_comparison()
     call test_timing_measurement()
-    
+
     ! Summary
     write(*,*) ""
     write(*,'(A,I0,A,I0)') "Tests passed: ", passed_tests, "/", test_count
@@ -22,111 +22,111 @@ program test_freefem_benchmark
         write(*,*) "✗ Some tests failed!"
         stop 1
     end if
-    
+
 contains
 
     subroutine test_benchmark_setup()
         character(len=*), parameter :: test_name = "Benchmark Setup"
         type(mesh_t) :: mesh
         real(dp) :: start_time, end_time
-        
+
         call start_test(test_name)
-        
+
         ! Test that we can measure timing for mesh generation
         call cpu_time(start_time)
-        mesh = unit_square_mesh(10)  ! 10x10 mesh for benchmark
+        mesh = unit_square_mesh(10) ! 10x10 mesh for benchmark
         call cpu_time(end_time)
-        
+
         write(*,'(A,ES10.3,A)') "  FortFEM mesh time: ", end_time - start_time, " seconds"
         write(*,'(A,I0)') "  Generated vertices: ", mesh%data%n_vertices
         write(*,'(A,I0)') "  Generated triangles: ", mesh%data%n_triangles
-        
+
         ! Validation for benchmark
         call assert_equal(mesh%data%n_vertices, 100, "10x10 = 100 vertices")
         call assert_true(mesh%data%n_triangles > 0, "Has triangles")
         call assert_true(end_time > start_time, "Time measurement works")
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_mesh_comparison()
         character(len=*), parameter :: test_name = "Mesh Quality Comparison"
         type(mesh_t) :: mesh_coarse, mesh_fine
         real(dp) :: coarse_time, fine_time, start_time, end_time
-        
+
         call start_test(test_name)
-        
+
         ! Coarse mesh timing
         call cpu_time(start_time)
         mesh_coarse = unit_square_mesh(5)
         call cpu_time(end_time)
         coarse_time = end_time - start_time
-        
-        ! Fine mesh timing  
+
+        ! Fine mesh timing
         call cpu_time(start_time)
         mesh_fine = unit_square_mesh(20)
         call cpu_time(end_time)
         fine_time = end_time - start_time
-        
+
         write(*,'(A,I0,A,ES10.3,A)') "  Coarse (5x5): ", mesh_coarse%data%n_triangles, " triangles, ", coarse_time, "s"
         write(*,'(A,I0,A,ES10.3,A)') "  Fine (20x20): ", mesh_fine%data%n_triangles, " triangles, ", fine_time, "s"
-        
+
         ! Scaling validation
         call assert_true(mesh_fine%data%n_triangles > mesh_coarse%data%n_triangles, "Fine mesh has more triangles")
         call assert_true(fine_time >= coarse_time, "Fine mesh takes longer (expected)")
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_timing_measurement()
         character(len=*), parameter :: test_name = "Timing Measurement Accuracy"
         real(dp) :: times(5), mean_time, std_dev
         integer :: i
-        
+
         call start_test(test_name)
-        
+
         ! Run multiple timing measurements for statistical accuracy
         do i = 1, 5
             times(i) = time_mesh_generation()
         end do
-        
+
         mean_time = sum(times) / 5.0_dp
         std_dev = sqrt(sum((times - mean_time)**2) / 4.0_dp)
-        
+
         write(*,'(A,ES10.3,A,ES10.3,A)') "  Mean time: ", mean_time, " ± ", std_dev, " seconds"
         write(*,'(A,ES8.1,A)') "  Relative std dev: ", 100.0_dp * std_dev / mean_time, "%"
-        
+
         ! Validation for benchmark reliability
         call assert_true(mean_time > 0.0_dp, "Mean time positive")
         call assert_true(std_dev / mean_time < 0.5_dp, "Timing reasonably consistent")
-        
+
         call end_test()
     end subroutine
-    
+
     ! Helper functions
     real(dp) function time_mesh_generation() result(elapsed)
         real(dp) :: start_time, end_time
         type(mesh_t) :: mesh
-        
+
         call cpu_time(start_time)
-        mesh = unit_square_mesh(15)  ! Standard benchmark size
+        mesh = unit_square_mesh(15) ! Standard benchmark size
         call cpu_time(end_time)
-        
+
         elapsed = end_time - start_time
     end function
-    
+
     ! Test framework helpers
     subroutine start_test(test_name)
         character(len=*), intent(in) :: test_name
         test_count = test_count + 1
         write(*,'(A,I0,A,A)') "Test ", test_count, ": ", test_name
     end subroutine
-    
+
     subroutine end_test()
         passed_tests = passed_tests + 1
         write(*,*) "  ✓ PASSED"
     end subroutine
-    
+
     subroutine assert_equal(actual, expected, description)
         integer, intent(in) :: actual, expected
         character(len=*), intent(in) :: description
@@ -135,7 +135,7 @@ contains
             stop 1
         end if
     end subroutine
-    
+
     subroutine assert_true(condition, description)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: description

--- a/test/test_geometry_check.f90
+++ b/test/test_geometry_check.f90
@@ -8,18 +8,18 @@ program test_geometry_check
     type(point_t) :: p1, p2, p3
     integer :: orient
     real(dp) :: area
-    
+
     write(*,*) "=== Geometry Check ==="
-    
+
     ! Create the 3 points
     p1%x = 0.0_dp; p1%y = 0.0_dp
-    p2%x = 1.0_dp; p2%y = 0.0_dp  
+    p2%x = 1.0_dp; p2%y = 0.0_dp
     p3%x = 0.5_dp; p3%y = 1.0_dp
-    
+
     write(*,'(A,2F8.3)') "Point 1: ", p1%x, p1%y
     write(*,'(A,2F8.3)') "Point 2: ", p2%x, p2%y
     write(*,'(A,2F8.3)') "Point 3: ", p3%x, p3%y
-    
+
     ! Check orientation
     orient = orientation(p1, p2, p3)
     write(*,*) "Orientation P1->P2->P3:", orient
@@ -30,11 +30,11 @@ program test_geometry_check
     else
         write(*,*) "  Collinear (degenerate)"
     end if
-    
+
     ! Calculate area
     area = triangle_area(p1, p2, p3)
     write(*,'(A,F12.6)') "Triangle area: ", area
-    
+
     if (area > 1.0e-10_dp) then
         write(*,*) "Triangle is valid (non-degenerate)"
     else

--- a/test/test_insertion_debug.f90
+++ b/test/test_insertion_debug.f90
@@ -8,48 +8,48 @@ program test_insertion_debug
     type(mesh_t) :: mesh
     real(dp) :: points(2, 3)
     integer :: i, super_tri_idx, point_idx
-    
+
     write(*,*) "=== Point Insertion Debug ==="
-    
+
     ! Create simple triangle: (0,0), (1,0), (0.5,1)
     points(:, 1) = [0.0_dp, 0.0_dp]
     points(:, 2) = [1.0_dp, 0.0_dp]
     points(:, 3) = [0.5_dp, 1.0_dp]
-    
+
     ! Initialize mesh
     call create_mesh(mesh, 6, 18, 9)
-    
+
     ! Create super-triangle
     write(*,*) "Creating super-triangle..."
     call create_super_triangle(points, mesh, super_tri_idx)
     write(*,*) "Super-triangle created. Triangle index:", super_tri_idx
     write(*,*) "Super-triangle vertices:", mesh%super_vertices
-    
+
     ! Add input points
     write(*,*) "Adding input points..."
     do i = 1, 3
         point_idx = add_point(mesh, points(1, i), points(2, i), i)
         write(*,'(A,I0,A,2F8.3,A,I0)') "  Point ", i, " at (", points(:, i), ") -> vertex ", point_idx
     end do
-    
+
     write(*,*) "After adding points:"
     write(*,*) "  Total vertices:", mesh%npoints
     write(*,*) "  Total triangles:", mesh%ntriangles
-    
+
     ! Insert points one by one with detailed output
     do i = 4, mesh%npoints
         write(*,*) ""
         write(*,'(A,I0,A,2F8.3,A,I0)') "Inserting vertex ", i, " at (", &
             mesh%points(i)%x, mesh%points(i)%y, ") with ID ", mesh%points(i)%id
-        
+
         ! Count valid triangles before insertion
         write(*,*) "  Valid triangles before insertion:", count_valid_triangles(mesh)
-        
+
         call insert_point(mesh, i)
-        
+
         ! Count valid triangles after insertion
         write(*,*) "  Valid triangles after insertion:", count_valid_triangles(mesh)
-        
+
         ! Show all triangles
         call show_all_triangles(mesh)
     end do
@@ -68,7 +68,7 @@ contains
     subroutine show_all_triangles(mesh)
         type(mesh_t), intent(in) :: mesh
         integer :: j
-        
+
         write(*,*) "  Current triangles:"
         do j = 1, mesh%ntriangles
             if (mesh%triangles(j)%valid) then

--- a/test/test_lshape_cdt_hole.f90
+++ b/test/test_lshape_cdt_hole.f90
@@ -30,9 +30,9 @@ program test_lshape_cdt_hole
         v3 = mesh%data%triangles(3, t)
 
         cx = (mesh%data%vertices(1, v1) + mesh%data%vertices(1, v2) +          &
-              mesh%data%vertices(1, v3)) / 3.0_dp
+            mesh%data%vertices(1, v3)) / 3.0_dp
         cy = (mesh%data%vertices(2, v1) + mesh%data%vertices(2, v2) +          &
-              mesh%data%vertices(2, v3)) / 3.0_dp
+            mesh%data%vertices(2, v3)) / 3.0_dp
 
         if (cx > size + eps .and. cy < size - eps) then
             n_bad = n_bad + 1

--- a/test/test_lshape_hole_refinement_comparison.f90
+++ b/test/test_lshape_hole_refinement_comparison.f90
@@ -3,11 +3,11 @@ program test_lshape_hole_refinement_comparison
     !> including one level of uniform mesh refinement, and write plots.
     use fortfem_kinds, only : dp
     use fortfem_api,  only : mesh_t, boundary_t, l_shape_boundary,          &
-                             mesh_from_boundary, mesh_from_arrays,          &
-                             mesh_from_triangle_files, refine_uniform,      &
-                             plot
+        mesh_from_boundary, mesh_from_arrays,          &
+        mesh_from_triangle_files, refine_uniform,      &
+        plot
     use triangulation_fortran, only : triangulation_result_t,               &
-                                      triangulate_with_hole_fortran
+        triangulate_with_hole_fortran
     use triangle_io, only : write_triangle_poly_file, ensure_triangle_available
     use check, only : check_condition, check_summary
     implicit none
@@ -45,38 +45,38 @@ program test_lshape_hole_refinement_comparison
     write(*,*) ""
     write(*,*) "=== Writing comparison plots (base meshes) ==="
     call plot(fortfem_mesh,                                                  &
-              filename="build/lshape_hole_fortfem.png",                      &
-              title="FortFEM L-shape with Hole")
+        filename="build/lshape_hole_fortfem.png",                      &
+        title="FortFEM L-shape with Hole")
     write(*,*) "   Saved: build/lshape_hole_fortfem.png"
 
     if (triangle_ok) then
         call plot(triangle_mesh,                                             &
-                  filename="build/lshape_hole_triangle.png",                 &
-                  title="Triangle L-shape with Hole")
+            filename="build/lshape_hole_triangle.png",                 &
+            title="Triangle L-shape with Hole")
         write(*,*) "   Saved: build/lshape_hole_triangle.png"
     end if
 
     write(*,*) ""
     write(*,*) "=== Writing comparison plots (refined meshes) ==="
     call plot(fortfem_refined,                                               &
-              filename="build/lshape_hole_fortfem_refined.png",              &
-              title="FortFEM L-shape with Hole (refined)")
+        filename="build/lshape_hole_fortfem_refined.png",              &
+        title="FortFEM L-shape with Hole (refined)")
     write(*,*) "   Saved: build/lshape_hole_fortfem_refined.png"
 
     if (triangle_ok) then
         call plot(triangle_refined,                                          &
-                  filename="build/lshape_hole_triangle_refined.png",         &
-                  title="Triangle L-shape with Hole (refined)")
+            filename="build/lshape_hole_triangle_refined.png",         &
+            title="Triangle L-shape with Hole (refined)")
         write(*,*) "   Saved: build/lshape_hole_triangle_refined.png"
     end if
 
     call check_condition(fortfem_refined%data%n_triangles >                  &
-                         fortfem_mesh%data%n_triangles,                      &
+        fortfem_mesh%data%n_triangles,                      &
         "FortFEM refined mesh has more triangles")
 
     if (triangle_ok) then
         call check_condition(triangle_refined%data%n_triangles >             &
-                             triangle_mesh%data%n_triangles,                 &
+            triangle_mesh%data%n_triangles,                 &
             "Triangle refined mesh has more triangles")
     end if
 
@@ -126,7 +126,7 @@ contains
 
         hole_pts(:,1) = hpt(:)
         call triangulate_with_hole_fortran(pts, segs, hole_pts,              &
-                                           result, status)
+            result, status)
 
         if (status /= 0) then
             write(*,*) "Warning: triangulate_with_hole_fortran returned ",   &
@@ -158,7 +158,7 @@ contains
         hole_points(:,1) = hpt(:)
 
         call write_triangle_poly_file(POLY_FILE // ".poly", pts, segs,       &
-                                      n, size(segs,2), stat, hole_points)
+            n, size(segs,2), stat, hole_points)
         if (stat /= 0) then
             write(*,*) "   Warning: Failed to write .poly file for L-shape hole"
             return

--- a/test/test_lshape_mesh_plot.f90
+++ b/test/test_lshape_mesh_plot.f90
@@ -26,7 +26,7 @@ program test_lshape_mesh_plot
         "L-shape mesh: boundary vertices identified")
 
     call plot(mesh, filename="build/test_lshape_boundary_mesh.png", &
-              title="L-shape Delaunay mesh")
+        title="L-shape Delaunay mesh")
 
     write(*,*) "   L-shape Delaunay plot: generated build/test_lshape_boundary_mesh.png"
 

--- a/test/test_mesh_boundaries_module.f90
+++ b/test/test_mesh_boundaries_module.f90
@@ -2,8 +2,8 @@ program test_mesh_boundaries_module
     use fortfem_kinds, only: dp
     use fortfem_boundary, only: boundary_t
     use fortfem_api_mesh_boundaries, only: circle_boundary, &
-                                           rectangle_boundary, line_segment, &
-                                               arc_segment, l_shape_boundary
+        rectangle_boundary, line_segment, &
+        arc_segment, l_shape_boundary
     use check, only: check_condition, check_summary
     implicit none
 
@@ -19,26 +19,26 @@ program test_mesh_boundaries_module
     circle = circle_boundary([0.0_dp, 0.0_dp], radius, n)
 
     call check_condition(circle%n_points == n, &
-                         "circle_boundary: correct number of points")
+        "circle_boundary: correct number of points")
     call check_condition(size(circle%labels) == n - 1, &
-                         "circle_boundary: correct number of edge labels")
+        "circle_boundary: correct number of edge labels")
     call check_condition(circle%is_closed, &
-                         "circle_boundary: boundary is closed")
+        "circle_boundary: boundary is closed")
 
     radius_point = sqrt(circle%points(1, 1)**2 + circle%points(2, 1)**2)
     call check_condition(abs(radius_point - radius) < 1.0e-10_dp, &
-                         "circle_boundary: points lie on circle")
+        "circle_boundary: points lie on circle")
 
     ! Rectangle boundary: label distribution and closure
     n = 5
     square = rectangle_boundary([0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp], n)
 
     call check_condition(square%n_points == 4*n, &
-                         "rectangle_boundary: correct number of points")
+        "rectangle_boundary: correct number of points")
     call check_condition(size(square%labels) == 4*n - 1, &
-                         "rectangle_boundary: correct number of edge labels")
+        "rectangle_boundary: correct number of edge labels")
     call check_condition(square%is_closed, &
-                         "rectangle_boundary: boundary is closed")
+        "rectangle_boundary: boundary is closed")
 
     n_label_1 = count(square%labels == 1)
     n_label_2 = count(square%labels == 2)
@@ -46,38 +46,38 @@ program test_mesh_boundaries_module
     n_label_4 = count(square%labels == 4)
 
     call check_condition(n_label_1 == n - 1, &
-                         "rectangle_boundary: correct count for label 1")
+        "rectangle_boundary: correct count for label 1")
     call check_condition(n_label_2 == n - 1, &
-                         "rectangle_boundary: correct count for label 2")
+        "rectangle_boundary: correct count for label 2")
     call check_condition(n_label_3 == n - 1, &
-                         "rectangle_boundary: correct count for label 3")
+        "rectangle_boundary: correct count for label 3")
     call check_condition(n_label_4 == n + 2, &
-                         "rectangle_boundary: correct count for label 4")
+        "rectangle_boundary: correct count for label 4")
 
     ! Line segment: open boundary with uniform spacing
     line = line_segment([0.0_dp, 0.0_dp], [1.0_dp, 0.0_dp], 4)
 
     call check_condition(.not. line%is_closed, &
-                         "line_segment: boundary is open")
+        "line_segment: boundary is open")
     call check_condition(line%n_points == 4, &
-                         "line_segment: correct number of points")
+        "line_segment: correct number of points")
 
     ! Arc segment: open boundary between two points on circle
     arc = arc_segment([1.0_dp, 0.0_dp], [0.0_dp, 1.0_dp], &
-                      [0.0_dp, 0.0_dp], 5)
+        [0.0_dp, 0.0_dp], 5)
 
     call check_condition(.not. arc%is_closed, &
-                         "arc_segment: boundary is open")
+        "arc_segment: boundary is open")
     call check_condition(arc%n_points == 5, &
-                         "arc_segment: correct number of points")
+        "arc_segment: correct number of points")
 
     ! L-shape boundary: closed boundary with expected point count
     lshape = l_shape_boundary(1.0_dp, 24)
 
     call check_condition(lshape%is_closed, &
-                         "l_shape_boundary: boundary is closed")
+        "l_shape_boundary: boundary is closed")
     call check_condition(lshape%n_points > 0, &
-                         "l_shape_boundary: positive number of points")
+        "l_shape_boundary: positive number of points")
 
     call check_summary("fortfem_api_mesh_boundaries")
 

--- a/test/test_mesh_integration.f90
+++ b/test/test_mesh_integration.f90
@@ -5,15 +5,15 @@ program test_mesh_integration
     implicit none
 
     integer :: test_count = 0, passed_tests = 0
-    
+
     write(*,*) "=== FortFEM Mesh Integration Tests ==="
     write(*,*) ""
-    
+
     call test_unit_disk_triangulation()
     call test_circle_boundary_mesh()
     call test_square_boundary_mesh()
     call test_mesh_from_domain_square()
-    
+
     ! Summary
     write(*,*) ""
     write(*,'(A,I0,A,I0)') "Tests passed: ", passed_tests, "/", test_count
@@ -23,81 +23,81 @@ program test_mesh_integration
         write(*,*) "✗ Some tests failed!"
         stop 1
     end if
-    
+
 contains
 
     subroutine test_unit_disk_triangulation()
         character(len=*), parameter :: test_name = "Unit Disk Triangulation"
         type(mesh_t) :: mesh
-        
+
         call start_test(test_name)
-        
+
         ! Test unit disk mesh generation using Delaunay backend
         mesh = unit_disk_mesh(resolution=0.2_dp)
-        
+
         write(*,'(A,I0)') "  Generated vertices: ", mesh%data%n_vertices
         write(*,'(A,I0)') "  Generated triangles: ", mesh%data%n_triangles
-        
+
         ! Basic validation
         call assert_true(mesh%data%n_vertices >= 3, "At least 3 vertices")
         call assert_true(mesh%data%n_triangles >= 1, "At least 1 triangle")
         call assert_true(allocated(mesh%data%vertices), "Vertices allocated")
         call assert_true(allocated(mesh%data%triangles), "Triangles allocated")
-        
+
         ! Visual inspection output
         call plot(mesh, filename="build/test_unit_disk_mesh.png")
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_circle_boundary_mesh()
         character(len=*), parameter :: test_name = "Circle Boundary Mesh"
         type(boundary_t) :: boundary
         type(mesh_t) :: mesh
-        
+
         call start_test(test_name)
-        
+
         ! Create circle boundary
         boundary = circle_boundary([0.0_dp, 0.0_dp], 1.0_dp, 12)
-        
+
         ! Generate mesh from boundary
         mesh = mesh_from_boundary(boundary, resolution=0.3_dp)
-        
+
         write(*,'(A,I0)') "  Boundary points: ", boundary%n_points
         write(*,'(A,I0)') "  Generated vertices: ", mesh%data%n_vertices
         write(*,'(A,I0)') "  Generated triangles: ", mesh%data%n_triangles
-        
+
         ! Validation
         call assert_true(mesh%data%n_vertices >= boundary%n_points, "At least boundary points")
         call assert_true(mesh%data%n_triangles >= 1, "At least 1 triangle")
         call assert_true(boundary%is_closed, "Boundary is closed")
-        
+
         ! Visual inspection output
         call plot(mesh, filename="build/test_circle_boundary_mesh.png")
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_square_boundary_mesh()
         character(len=*), parameter :: test_name = "Square Boundary Mesh"
         type(boundary_t) :: boundary
         type(mesh_t) :: mesh
         integer :: n
         integer :: n_label_1, n_label_2, n_label_3, n_label_4
-        
+
         call start_test(test_name)
-        
+
         ! Create rectangle boundary
         n = 5
         boundary = rectangle_boundary([0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp], n)
-        
-        ! Generate mesh from boundary  
+
+        ! Generate mesh from boundary
         mesh = mesh_from_boundary(boundary, resolution=0.2_dp)
-        
+
         write(*,'(A,I0)') "  Boundary points: ", boundary%n_points
         write(*,'(A,I0)') "  Generated vertices: ", mesh%data%n_vertices
         write(*,'(A,I0)') "  Generated triangles: ", mesh%data%n_triangles
-        
+
         ! Validation
         call assert_true(boundary%n_points == 4 * n, &
             "Square boundary: correct number of points")
@@ -122,10 +122,10 @@ contains
             "Square boundary: correct count for label 3")
         call assert_true(n_label_4 == n + 2, &
             "Square boundary: correct count for label 4")
-        
+
         ! Visual inspection output
         call plot(mesh, filename="build/test_square_boundary_mesh.png")
-        
+
         call end_test()
     end subroutine
 
@@ -162,19 +162,19 @@ contains
 
         call end_test()
     end subroutine test_mesh_from_domain_square
-    
+
     ! Test framework helpers
     subroutine start_test(test_name)
         character(len=*), intent(in) :: test_name
         test_count = test_count + 1
         write(*,'(A,I0,A,A)') "Test ", test_count, ": ", test_name
     end subroutine
-    
+
     subroutine end_test()
         passed_tests = passed_tests + 1
         write(*,*) "  ✓ PASSED"
     end subroutine
-    
+
     subroutine assert_true(condition, description)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: description

--- a/test/test_mesh_plotting.f90
+++ b/test/test_mesh_plotting.f90
@@ -5,16 +5,16 @@ program test_mesh_plotting
     implicit none
 
     integer :: test_count = 0, passed_tests = 0
-    
+
     write(*,*) "=== Mesh Plotting TDD Tests ==="
     write(*,*) ""
-    
+
     call test_plot_function_exists()
     call test_simple_mesh_plot()
     call test_plot_with_options()
     call test_quad_mesh_plot()
     call test_mixed_mesh_plot()
-    
+
     ! Summary
     write(*,*) ""
     write(*,'(A,I0,A,I0)') "Tests passed: ", passed_tests, "/", test_count
@@ -24,39 +24,39 @@ program test_mesh_plotting
         write(*,*) "✗ Some tests failed!"
         stop 1
     end if
-    
+
 contains
 
     subroutine test_plot_function_exists()
         character(len=*), parameter :: test_name = "Plot Function Interface"
         type(mesh_t) :: mesh
-        
+
         call start_test(test_name)
-        
+
         mesh = unit_square_mesh(5)
-        
+
         ! Test that plot function can be called
         ! Expected: Simple wireframe plot showing triangulation
         write(*,*) "  Testing basic plot interface..."
-        call plot(mesh)  ! Should generate mesh plot
+        call plot(mesh) ! Should generate mesh plot
         write(*,*) "  ✓ plot(mesh) interface works"
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_quad_mesh_plot()
         character(len=*), parameter :: test_name = "Quadrilateral Mesh Plot"
         type(mesh_t) :: mesh
-        
+
         call start_test(test_name)
-        
+
         mesh = structured_quad_mesh(4, 3, 0.0_dp, 2.0_dp, 0.0_dp, 1.0_dp)
-        
+
         write(*,*) "  Testing quadrilateral mesh plotting..."
         call plot(mesh, filename="build/test_quad_mesh.png", &
-                  title="Structured Quad Mesh")
+            title="Structured Quad Mesh")
         write(*,*) "  ✓ plot(quad mesh) works"
-        
+
         call end_test()
     end subroutine
 
@@ -64,26 +64,26 @@ contains
         character(len=*), parameter :: test_name = "Mixed Mesh Plot"
         type(mesh_t) :: tri_mesh, quad_mesh, mixed_mesh
         integer :: n_vertices, i
-        
+
         call start_test(test_name)
-        
+
         tri_mesh = unit_square_mesh(3)
         quad_mesh = structured_quad_mesh(2, 2, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
-        
+
         mixed_mesh%data%n_vertices = tri_mesh%data%n_vertices + quad_mesh%data%n_vertices
         mixed_mesh%data%n_triangles = tri_mesh%data%n_triangles
         mixed_mesh%data%n_quads = quad_mesh%data%n_quads
         mixed_mesh%data%has_triangles = .true.
         mixed_mesh%data%has_quads = .true.
         mixed_mesh%data%has_mixed_elements = .true.
-        
+
         allocate(mixed_mesh%data%vertices(2, mixed_mesh%data%n_vertices))
         allocate(mixed_mesh%data%triangles(3, mixed_mesh%data%n_triangles))
         allocate(mixed_mesh%data%quads(4, mixed_mesh%data%n_quads))
-        
+
         mixed_mesh%data%vertices(:, 1:tri_mesh%data%n_vertices) = tri_mesh%data%vertices
         mixed_mesh%data%triangles = tri_mesh%data%triangles
-        
+
         n_vertices = tri_mesh%data%n_vertices
         do i = 1, quad_mesh%data%n_vertices
             mixed_mesh%data%vertices(:, n_vertices + i) = quad_mesh%data%vertices(:, i) + &
@@ -92,58 +92,58 @@ contains
         do i = 1, quad_mesh%data%n_quads
             mixed_mesh%data%quads(:, i) = quad_mesh%data%quads(:, i) + n_vertices
         end do
-        
+
         call mixed_mesh%data%build_connectivity()
         call mixed_mesh%data%find_boundary()
-        
+
         write(*,*) "  Testing mixed tri/quad mesh plotting..."
         call plot(mixed_mesh, filename="build/test_mixed_mesh.png", &
-                  title="Mixed Tri/Quad Mesh")
+            title="Mixed Tri/Quad Mesh")
         write(*,*) "  ✓ plot(mixed mesh) works"
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_simple_mesh_plot()
         character(len=*), parameter :: test_name = "Simple Mesh Plot"
         type(mesh_t) :: mesh
-        
+
         call start_test(test_name)
-        
+
         mesh = unit_square_mesh(4)
-        
+
         ! Test basic mesh plotting with filename
         write(*,*) "  Testing plot with filename..."
         call plot(mesh, filename="build/test_mesh.png")
         write(*,*) "  ✓ plot(mesh, filename) works"
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_plot_with_options()
         character(len=*), parameter :: test_name = "Plot with Options"
         type(mesh_t) :: mesh
-        
+
         call start_test(test_name)
-        
+
         mesh = rectangle_mesh(3, 4, [0.0_dp, 2.0_dp, 0.0_dp, 1.0_dp])
-        
+
         ! Test mesh plotting with various options
         write(*,*) "  Testing plot with title and options..."
         call plot(mesh, filename="build/test_mesh_titled.png", &
-                  title="Rectangle Mesh", show_labels=.false.)
+            title="Rectangle Mesh", show_labels=.false.)
         write(*,*) "  ✓ plot(mesh, options) works"
-        
+
         call end_test()
     end subroutine
-    
+
     ! Test framework helpers
     subroutine start_test(test_name)
         character(len=*), intent(in) :: test_name
         test_count = test_count + 1
         write(*,'(A,I0,A,A)') "Test ", test_count, ": ", test_name
     end subroutine
-    
+
     subroutine end_test()
         passed_tests = passed_tests + 1
         write(*,*) "  ✓ PASSED"

--- a/test/test_mesh_refinement.f90
+++ b/test/test_mesh_refinement.f90
@@ -6,7 +6,7 @@ program test_mesh_refinement
     implicit none
 
     write(*,*) "Testing mesh refinement implementation..."
-    
+
     call test_uniform_refinement()
     call test_uniform_refinement_levels()
     call test_adaptive_refinement()
@@ -17,7 +17,7 @@ program test_mesh_refinement
     call test_solution_transfer()
     call test_refinement_convergence()
     call test_adaptive_refinement_api()
-    
+
     call check_summary("Mesh Refinement")
 
 contains
@@ -28,19 +28,19 @@ contains
         integer :: original_vertices, original_triangles
         integer :: refined_vertices, refined_triangles
         real(dp) :: original_area, refined_area
-        
+
         ! Create initial mesh
         mesh = unit_square_mesh(3)
         original_vertices = mesh%data%n_vertices
         original_triangles = mesh%data%n_triangles
         original_area = compute_total_area(mesh)
-        
+
         ! Uniform refinement
         refined_mesh = refine_uniform(mesh)
         refined_vertices = refined_mesh%data%n_vertices
         refined_triangles = refined_mesh%data%n_triangles
         refined_area = compute_total_area(refined_mesh)
-        
+
         ! Each triangle should split into 4, vertices increase by edge count + original
         call check_condition(refined_triangles == 4 * original_triangles, &
             "Uniform refinement: triangles quadruple")
@@ -50,7 +50,7 @@ contains
             "Uniform refinement: area preserved")
         call check_condition(refined_triangles > 0, &
             "Uniform refinement: mesh validity")
-        
+
         write(*,*) "   Original: ", original_vertices, "vertices,", original_triangles, "triangles"
         write(*,*) "   Refined:  ", refined_vertices, "vertices,", refined_triangles, "triangles"
         write(*,*) "   Area preservation:", abs(refined_area - original_area)
@@ -60,21 +60,21 @@ contains
     subroutine test_uniform_refinement_levels()
         type(mesh_t) :: mesh, mesh_l1, mesh_l2
         integer :: original_triangles
-        
+
         mesh = unit_square_mesh(3)
         original_triangles = mesh%data%n_triangles
-        
+
         mesh_l1 = refine_uniform(mesh)
         mesh_l2 = refine_uniform(mesh, 2)
-        
+
         call check_condition(mesh_l1%data%n_triangles == 4 * original_triangles, &
             "Uniform refinement levels: 1 level quadruples triangles")
         call check_condition(mesh_l2%data%n_triangles == 16 * original_triangles, &
             "Uniform refinement levels: 2 levels give 16x triangles")
-        
+
         write(*,*) "   Uniform levels: nT0=", original_triangles, &
-                   " nT1=", mesh_l1%data%n_triangles, &
-                   " nT2=", mesh_l2%data%n_triangles
+            " nT1=", mesh_l1%data%n_triangles, &
+            " nT2=", mesh_l2%data%n_triangles
     end subroutine test_uniform_refinement_levels
 
     ! Test adaptive mesh refinement
@@ -83,16 +83,16 @@ contains
         logical, allocatable :: refine_markers(:)
         integer :: original_triangles, refined_triangles, marked_count
         integer :: i
-        
+
         ! Create initial mesh
         mesh = unit_square_mesh(4)
         original_triangles = mesh%data%n_triangles
-        
+
         ! Mark triangles for refinement (e.g., those in center region)
         allocate(refine_markers(original_triangles))
         refine_markers = .false.
         marked_count = 0
-        
+
         do i = 1, original_triangles
             ! Mark triangles near center (x ≈ 0.5, y ≈ 0.5)
             if (triangle_near_center(mesh, i, 0.5_dp, 0.5_dp, 0.3_dp)) then
@@ -100,11 +100,11 @@ contains
                 marked_count = marked_count + 1
             end if
         end do
-        
+
         ! Adaptive refinement
         refined_mesh = refine_adaptive(mesh, refine_markers)
         refined_triangles = refined_mesh%data%n_triangles
-        
+
         call check_condition(refined_triangles > original_triangles, &
             "Adaptive refinement: triangle count increases")
         call check_condition(refined_triangles < 4 * original_triangles, &
@@ -113,11 +113,11 @@ contains
             "Adaptive refinement: some triangles marked")
         call check_condition(mesh_is_conforming(refined_mesh), &
             "Adaptive refinement: mesh conformity maintained")
-        
+
         write(*,*) "   Original triangles:", original_triangles
         write(*,*) "   Marked triangles:", marked_count
         write(*,*) "   Refined triangles:", refined_triangles
-        
+
         deallocate(refine_markers)
     end subroutine test_adaptive_refinement
 
@@ -164,18 +164,18 @@ contains
         integer :: original_boundary_vertices, refined_boundary_vertices
         integer :: original_boundary_edges, refined_boundary_edges
         logical :: boundary_preserved
-        
+
         ! Create mesh with clear boundary
         mesh = unit_square_mesh(4)
         original_boundary_vertices = count_boundary_vertices(mesh)
         original_boundary_edges = count_boundary_edges(mesh)
-        
+
         ! Refine uniformly
         refined_mesh = refine_uniform(mesh)
         refined_boundary_vertices = count_boundary_vertices(refined_mesh)
         refined_boundary_edges = count_boundary_edges(refined_mesh)
         boundary_preserved = check_boundary_integrity(refined_mesh)
-        
+
         call check_condition(refined_boundary_vertices > original_boundary_vertices, &
             "Boundary preservation: boundary vertex count increases")
         call check_condition(refined_boundary_edges > original_boundary_edges, &
@@ -184,7 +184,7 @@ contains
             "Boundary preservation: boundary integrity maintained")
         call check_condition(verify_boundary_geometry(refined_mesh), &
             "Boundary preservation: boundary geometry correct")
-        
+
         write(*,*) "   Original boundary vertices:", original_boundary_vertices
         write(*,*) "   Refined boundary vertices:", refined_boundary_vertices
         write(*,*) "   Boundary integrity:", boundary_preserved
@@ -196,19 +196,19 @@ contains
         real(dp) :: original_min_angle, refined_min_angle
         real(dp) :: original_max_area, refined_max_area
         real(dp) :: original_quality, refined_quality
-        
+
         ! Create initial mesh
         mesh = unit_square_mesh(3)
         original_min_angle = compute_minimum_angle(mesh)
         original_max_area = compute_maximum_area(mesh)
         original_quality = compute_mesh_quality(mesh)
-        
+
         ! Refine uniformly
         refined_mesh = refine_uniform(mesh)
         refined_min_angle = compute_minimum_angle(refined_mesh)
         refined_max_area = compute_maximum_area(refined_mesh)
         refined_quality = compute_mesh_quality(refined_mesh)
-        
+
         call check_condition(refined_min_angle >= 0.9_dp * original_min_angle, &
             "Mesh quality: minimum angle preserved")
         call check_condition(refined_max_area <= 0.3_dp * original_max_area, &
@@ -217,7 +217,7 @@ contains
             "Mesh quality: overall quality maintained")
         call check_condition(refined_min_angle > 15.0_dp * acos(-1.0_dp) / 180.0_dp, &
             "Mesh quality: reasonable minimum angle")
-        
+
         write(*,*) "   Original min angle (deg):", original_min_angle * 180.0_dp / acos(-1.0_dp)
         write(*,*) "   Refined min angle (deg):", refined_min_angle * 180.0_dp / acos(-1.0_dp)
         write(*,*) "   Area reduction factor:", refined_max_area / original_max_area
@@ -228,17 +228,17 @@ contains
         type(mesh_t) :: mesh, refined_mesh
         type(function_space_t) :: Vh_coarse, Vh_fine
         integer :: coarse_dofs, fine_dofs
-        
+
         ! Create mesh and function space
         mesh = unit_square_mesh(3)
         Vh_coarse = function_space(mesh, "Lagrange", 1)
         coarse_dofs = Vh_coarse%ndof
-        
+
         ! Refine mesh and create new function space
         refined_mesh = refine_uniform(mesh)
         Vh_fine = function_space(refined_mesh, "Lagrange", 1)
         fine_dofs = Vh_fine%ndof
-        
+
         call check_condition(fine_dofs > coarse_dofs, &
             "Function space refinement: DOF count increases")
         call check_condition(fine_dofs == refined_mesh%data%n_vertices, &
@@ -247,7 +247,7 @@ contains
             "Function space refinement: degree preserved")
         call check_condition(trim(Vh_fine%element_family) == "Lagrange", &
             "Function space refinement: element family preserved")
-        
+
         write(*,*) "   Coarse DOFs:", coarse_dofs
         write(*,*) "   Fine DOFs:", fine_dofs
         write(*,*) "   DOF multiplication factor:", real(fine_dofs) / real(coarse_dofs)
@@ -260,12 +260,12 @@ contains
         type(function_t) :: uh_coarse, uh_fine, uh_transferred
         real(dp) :: coarse_norm, fine_norm, transfer_error
         integer :: i
-        
+
         ! Create coarse mesh and function space
         mesh = unit_square_mesh(3)
         Vh_coarse = function_space(mesh, "Lagrange", 1)
         uh_coarse = function(Vh_coarse)
-        
+
         ! Set up a test function on coarse mesh (e.g., quadratic function)
         do i = 1, Vh_coarse%ndof
             uh_coarse%values(i) = quadratic_test_function( &
@@ -273,32 +273,32 @@ contains
                 Vh_coarse%mesh%data%vertices(2, i))
         end do
         coarse_norm = sqrt(sum(uh_coarse%values**2))
-        
+
         ! Refine mesh and create fine function space
         refined_mesh = refine_uniform(mesh)
         Vh_fine = function_space(refined_mesh, "Lagrange", 1)
         uh_fine = function(Vh_fine)
-        
+
         ! Transfer solution from coarse to fine mesh
         call transfer_solution(uh_coarse, uh_fine, uh_transferred)
         fine_norm = sqrt(sum(uh_transferred%values**2))
-        
+
         ! Compute exact solution on fine mesh for comparison
         do i = 1, Vh_fine%ndof
             uh_fine%values(i) = quadratic_test_function( &
                 Vh_fine%mesh%data%vertices(1, i), &
                 Vh_fine%mesh%data%vertices(2, i))
         end do
-        
+
         transfer_error = sqrt(sum((uh_transferred%values - uh_fine%values)**2))
-        
+
         call check_condition(fine_norm > 0.5_dp * coarse_norm, &
             "Solution transfer: reasonable norm preservation")
         call check_condition(transfer_error < 0.5_dp * fine_norm, &
             "Solution transfer: reasonable interpolation error")
         call check_condition(size(uh_transferred%values) == Vh_fine%ndof, &
             "Solution transfer: correct fine mesh DOF count")
-        
+
         write(*,*) "   Coarse solution norm:", coarse_norm
         write(*,*) "   Fine solution norm:", fine_norm
         write(*,*) "   Transfer error:", transfer_error
@@ -314,25 +314,25 @@ contains
         type(dirichlet_bc_t) :: bc1, bc2, bc3
         type(form_expr_t) :: a1, L1, a2, L2, a3, L3
         real(dp) :: errors(3), h_values(3), convergence_rate
-        
+
         ! Create sequence of refined meshes
         mesh1 = unit_square_mesh(2)
         mesh2 = refine_uniform(mesh1)
         mesh3 = refine_uniform(mesh2)
-        
+
         ! Solve same problem on each mesh
         call solve_on_mesh(mesh1, uh1, errors(1))
         call solve_on_mesh(mesh2, uh2, errors(2))
         call solve_on_mesh(mesh3, uh3, errors(3))
-        
+
         ! Estimate convergence rate
-        h_values = [0.5_dp, 0.25_dp, 0.125_dp]  ! Approximate h values
+        h_values = [0.5_dp, 0.25_dp, 0.125_dp] ! Approximate h values
         if (errors(1) > 1.0e-12_dp .and. errors(2) > 1.0e-12_dp) then
             convergence_rate = log(errors(2) / errors(1)) / log(h_values(2) / h_values(1))
         else
             convergence_rate = 0.0_dp
         end if
-        
+
         call check_condition(errors(2) < errors(1), &
             "Refinement convergence: error decreases with refinement 1")
         call check_condition(errors(3) < errors(2), &
@@ -341,39 +341,39 @@ contains
             "Refinement convergence: reasonable convergence rate")
         call check_condition(all(errors > 0.0_dp), &
             "Refinement convergence: positive errors")
-        
+
         write(*,*) "   Errors:", errors
-        write(*,*) "   h values:", h_values  
+        write(*,*) "   h values:", h_values
         write(*,*) "   Convergence rate:", convergence_rate
     end subroutine test_refinement_convergence
 
     ! Helper functions
-    
+
     function compute_total_area(mesh) result(total_area)
         type(mesh_t), intent(in) :: mesh
         real(dp) :: total_area
         integer :: i, v1, v2, v3
         real(dp) :: x1, y1, x2, y2, x3, y3, area
-        
+
         total_area = 0.0_dp
         do i = 1, mesh%data%n_triangles
             v1 = mesh%data%triangles(1, i)
-            v2 = mesh%data%triangles(2, i) 
+            v2 = mesh%data%triangles(2, i)
             v3 = mesh%data%triangles(3, i)
-            
+
             x1 = mesh%data%vertices(1, v1)
             y1 = mesh%data%vertices(2, v1)
-            x2 = mesh%data%vertices(1, v2) 
+            x2 = mesh%data%vertices(1, v2)
             y2 = mesh%data%vertices(2, v2)
             x3 = mesh%data%vertices(1, v3)
             y3 = mesh%data%vertices(2, v3)
-            
+
             ! Triangle area using cross product
             area = 0.5_dp * abs((x2 - x1) * (y3 - y1) - (x3 - x1) * (y2 - y1))
             total_area = total_area + area
         end do
     end function compute_total_area
-    
+
     function triangle_near_center(mesh, triangle_id, center_x, center_y, radius) result(is_near)
         type(mesh_t), intent(in) :: mesh
         integer, intent(in) :: triangle_id
@@ -381,32 +381,32 @@ contains
         logical :: is_near
         integer :: v1, v2, v3
         real(dp) :: centroid_x, centroid_y, distance
-        
+
         v1 = mesh%data%triangles(1, triangle_id)
         v2 = mesh%data%triangles(2, triangle_id)
         v3 = mesh%data%triangles(3, triangle_id)
-        
+
         ! Compute triangle centroid
         centroid_x = (mesh%data%vertices(1, v1) + mesh%data%vertices(1, v2) + &
-                     mesh%data%vertices(1, v3)) / 3.0_dp
+            mesh%data%vertices(1, v3)) / 3.0_dp
         centroid_y = (mesh%data%vertices(2, v1) + mesh%data%vertices(2, v2) + &
-                     mesh%data%vertices(2, v3)) / 3.0_dp
-        
+            mesh%data%vertices(2, v3)) / 3.0_dp
+
         ! Check distance from center
         distance = sqrt((centroid_x - center_x)**2 + (centroid_y - center_y)**2)
         is_near = (distance <= radius)
     end function triangle_near_center
-    
+
     function mesh_is_conforming(mesh) result(is_conforming)
         type(mesh_t), intent(in) :: mesh
         logical :: is_conforming
-        
+
         integer :: i, j, k, e, v1, v2, shared_edges
         real(dp) :: min_area, area
         real(dp), parameter :: tolerance = 1.0e-12_dp
-        
+
         is_conforming = .true.
-        
+
         ! Check 1: All triangles have positive area
         do i = 1, mesh%data%n_triangles
             area = compute_triangle_area(mesh, i)
@@ -415,28 +415,28 @@ contains
                 return
             end if
         end do
-        
+
         ! Check 2: Each edge belongs to at most 2 triangles
         do e = 1, mesh%data%n_edges
             shared_edges = 0
             v1 = mesh%data%edges(1, e)
             v2 = mesh%data%edges(2, e)
-            
+
             do i = 1, mesh%data%n_triangles
                 ! Check if triangle i contains edge (v1,v2)
                 if (triangle_contains_edge(mesh, i, v1, v2)) then
                     shared_edges = shared_edges + 1
                 end if
             end do
-            
+
             if (shared_edges > 2) then
                 is_conforming = .false.
                 return
             end if
         end do
-        
+
     end function mesh_is_conforming
-    
+
     function count_boundary_vertices(mesh) result(count)
         type(mesh_t), intent(in) :: mesh
         integer :: count
@@ -446,7 +446,7 @@ contains
             if (mesh%data%is_boundary_vertex(i)) count = count + 1
         end do
     end function count_boundary_vertices
-    
+
     function count_boundary_edges(mesh) result(count)
         type(mesh_t), intent(in) :: mesh
         integer :: count
@@ -456,151 +456,151 @@ contains
             if (mesh%data%is_boundary_edge(i)) count = count + 1
         end do
     end function count_boundary_edges
-    
+
     function check_boundary_integrity(mesh) result(is_intact)
         type(mesh_t), intent(in) :: mesh
         logical :: is_intact
-        
+
         integer :: i, j, e, v1, v2, triangle_count
-        
+
         is_intact = .true.
-        
+
         ! Check that each boundary edge belongs to exactly one triangle
         do i = 1, mesh%data%n_boundary_edges
             e = mesh%data%boundary_edges(i)
             v1 = mesh%data%edges(1, e)
             v2 = mesh%data%edges(2, e)
-            
+
             triangle_count = 0
             do j = 1, mesh%data%n_triangles
                 if (triangle_contains_edge_simple(mesh, j, v1, v2)) then
                     triangle_count = triangle_count + 1
                 end if
             end do
-            
+
             if (triangle_count /= 1) then
                 is_intact = .false.
                 return
             end if
         end do
-        
+
     end function check_boundary_integrity
-    
+
     function verify_boundary_geometry(mesh) result(is_correct)
         type(mesh_t), intent(in) :: mesh
         logical :: is_correct
         ! Placeholder - verify boundary geometry
         is_correct = .true.
     end function verify_boundary_geometry
-    
+
     function compute_minimum_angle(mesh) result(min_angle)
         type(mesh_t), intent(in) :: mesh
         real(dp) :: min_angle
-        
+
         integer :: i, v1, v2, v3
         real(dp) :: x1, y1, x2, y2, x3, y3
         real(dp) :: a, b, c, angle1, angle2, angle3
         real(dp), parameter :: pi = acos(-1.0_dp)
-        
-        min_angle = pi  ! Start with maximum possible angle
-        
+
+        min_angle = pi ! Start with maximum possible angle
+
         do i = 1, mesh%data%n_triangles
             v1 = mesh%data%triangles(1, i)
             v2 = mesh%data%triangles(2, i)
             v3 = mesh%data%triangles(3, i)
-            
+
             x1 = mesh%data%vertices(1, v1)
             y1 = mesh%data%vertices(2, v1)
             x2 = mesh%data%vertices(1, v2)
             y2 = mesh%data%vertices(2, v2)
             x3 = mesh%data%vertices(1, v3)
             y3 = mesh%data%vertices(2, v3)
-            
+
             ! Compute side lengths
-            a = sqrt((x2-x3)**2 + (y2-y3)**2)  ! Side opposite to vertex 1
-            b = sqrt((x1-x3)**2 + (y1-y3)**2)  ! Side opposite to vertex 2
-            c = sqrt((x1-x2)**2 + (y1-y2)**2)  ! Side opposite to vertex 3
-            
+            a = sqrt((x2-x3)**2 + (y2-y3)**2) ! Side opposite to vertex 1
+            b = sqrt((x1-x3)**2 + (y1-y3)**2) ! Side opposite to vertex 2
+            c = sqrt((x1-x2)**2 + (y1-y2)**2) ! Side opposite to vertex 3
+
             ! Avoid degenerate triangles
             if (a < 1.0e-12_dp .or. b < 1.0e-12_dp .or. c < 1.0e-12_dp) cycle
-            
+
             ! Compute angles using law of cosines
             angle1 = acos(min(1.0_dp, max(-1.0_dp, (b**2 + c**2 - a**2) / (2.0_dp * b * c))))
             angle2 = acos(min(1.0_dp, max(-1.0_dp, (a**2 + c**2 - b**2) / (2.0_dp * a * c))))
             angle3 = acos(min(1.0_dp, max(-1.0_dp, (a**2 + b**2 - c**2) / (2.0_dp * a * b))))
-            
+
             min_angle = min(min_angle, angle1, angle2, angle3)
         end do
     end function compute_minimum_angle
-    
+
     function compute_maximum_area(mesh) result(max_area)
         type(mesh_t), intent(in) :: mesh
         real(dp) :: max_area
         integer :: i, v1, v2, v3
         real(dp) :: x1, y1, x2, y2, x3, y3, area
-        
+
         max_area = 0.0_dp
         do i = 1, mesh%data%n_triangles
             v1 = mesh%data%triangles(1, i)
             v2 = mesh%data%triangles(2, i)
             v3 = mesh%data%triangles(3, i)
-            
+
             x1 = mesh%data%vertices(1, v1)
             y1 = mesh%data%vertices(2, v1)
             x2 = mesh%data%vertices(1, v2)
             y2 = mesh%data%vertices(2, v2)
             x3 = mesh%data%vertices(1, v3)
             y3 = mesh%data%vertices(2, v3)
-            
+
             ! Triangle area using cross product
             area = 0.5_dp * abs((x2 - x1) * (y3 - y1) - (x3 - x1) * (y2 - y1))
             if (area > max_area) max_area = area
         end do
     end function compute_maximum_area
-    
+
     function compute_mesh_quality(mesh) result(quality)
         type(mesh_t), intent(in) :: mesh
         real(dp) :: quality
-        
+
         real(dp) :: min_angle, max_area, avg_area
         real(dp) :: total_area, aspect_ratio_sum
         integer :: i
-        
+
         ! Quality based on minimum angle and area distribution
         min_angle = compute_minimum_angle(mesh)
         max_area = compute_maximum_area(mesh)
-        
+
         ! Compute average area
         total_area = 0.0_dp
         do i = 1, mesh%data%n_triangles
             total_area = total_area + compute_triangle_area_simple(mesh, i)
         end do
         avg_area = total_area / real(mesh%data%n_triangles, dp)
-        
+
         ! Quality metric: combine angle quality and area uniformity
         ! Angle quality: min_angle / (pi/3) for equilateral triangle
         ! Area uniformity: 1 - (max_area - avg_area) / avg_area
         quality = 0.7_dp * (min_angle / (acos(-1.0_dp) / 3.0_dp)) + &
-                 0.3_dp * (1.0_dp - min(1.0_dp, (max_area - avg_area) / avg_area))
-        
-        quality = max(0.0_dp, min(1.0_dp, quality))  ! Clamp to [0,1]
-        
+            0.3_dp * (1.0_dp - min(1.0_dp, (max_area - avg_area) / avg_area))
+
+        quality = max(0.0_dp, min(1.0_dp, quality)) ! Clamp to [0,1]
+
     end function compute_mesh_quality
-    
+
     function quadratic_test_function(x, y) result(val)
         real(dp), intent(in) :: x, y
         real(dp) :: val
         val = x * (1.0_dp - x) * y * (1.0_dp - y)
     end function quadratic_test_function
-    
+
     subroutine transfer_solution(uh_coarse, uh_fine, uh_transferred)
         type(function_t), intent(in) :: uh_coarse, uh_fine
         type(function_t), intent(out) :: uh_transferred
         integer :: i
         real(dp) :: x, y
-        
+
         ! Simple interpolation: evaluate coarse function at fine mesh points
-        uh_transferred = uh_fine  ! Copy structure
+        uh_transferred = uh_fine ! Copy structure
         if (allocated(uh_transferred%values)) then
             do i = 1, uh_fine%space%ndof
                 x = uh_fine%space%mesh%data%vertices(1, i)
@@ -610,7 +610,7 @@ contains
             end do
         end if
     end subroutine transfer_solution
-    
+
     subroutine solve_on_mesh(mesh, uh, error)
         type(mesh_t), intent(in) :: mesh
         type(function_t), intent(out) :: uh
@@ -619,7 +619,7 @@ contains
         integer :: i
         real(dp) :: x, y
         real(dp), parameter :: pi = acos(-1.0_dp)
-        
+
         Vh = function_space(mesh, "Lagrange", 1)
         uh = function(Vh)
         if (allocated(uh%values)) then
@@ -629,7 +629,7 @@ contains
                 uh%values(i) = sin(pi * x) * sin(pi * y)
             end do
         end if
-        
+
         error = compute_L2_interpolation_error(mesh, uh)
     end subroutine solve_on_mesh
 
@@ -642,29 +642,29 @@ contains
         real(dp) :: xc, yc, u_h_bar, u_exact, area
         real(dp) :: sum_sq
         real(dp), parameter :: pi = acos(-1.0_dp)
-        
+
         sum_sq = 0.0_dp
         do e = 1, mesh%data%n_triangles
             v1 = mesh%data%triangles(1, e)
             v2 = mesh%data%triangles(2, e)
             v3 = mesh%data%triangles(3, e)
-            
+
             x1 = mesh%data%vertices(1, v1)
             y1 = mesh%data%vertices(2, v1)
             x2 = mesh%data%vertices(1, v2)
             y2 = mesh%data%vertices(2, v2)
             x3 = mesh%data%vertices(1, v3)
             y3 = mesh%data%vertices(2, v3)
-            
+
             xc = (x1 + x2 + x3) / 3.0_dp
             yc = (y1 + y2 + y3) / 3.0_dp
             u_h_bar = (uh%values(v1) + uh%values(v2) + uh%values(v3)) / 3.0_dp
             u_exact = sin(pi * xc) * sin(pi * yc)
-            
+
             area = 0.5_dp * abs((x2-x1)*(y3-y1) - (x3-x1)*(y2-y1))
             sum_sq = sum_sq + (u_h_bar - u_exact)**2 * area
         end do
-        
+
         err = sqrt(sum_sq)
     end function compute_L2_interpolation_error
 
@@ -676,39 +676,39 @@ contains
         integer :: i
         real(dp) :: x, y
         real(dp), parameter :: pi = acos(-1.0_dp)
-        
+
         mesh_coarse = unit_square_mesh(4)
         Vh_coarse = function_space(mesh_coarse, "Lagrange", 1)
         uh_coarse = function(Vh_coarse)
-        
+
         do i = 1, Vh_coarse%ndof
             x = mesh_coarse%data%vertices(1, i)
             y = mesh_coarse%data%vertices(2, i)
             uh_coarse%values(i) = sin(pi * x) * sin(pi * y)
         end do
-        
+
         error_coarse = compute_L2_interpolation_error(mesh_coarse, uh_coarse)
-        
+
         mesh_adapt = refine_adaptive(mesh_coarse, uh_coarse, 0.5_dp)
         Vh_adapt = function_space(mesh_adapt, "Lagrange", 1)
         uh_adapt = function(Vh_adapt)
-        
+
         do i = 1, Vh_adapt%ndof
             x = mesh_adapt%data%vertices(1, i)
             y = mesh_adapt%data%vertices(2, i)
             uh_adapt%values(i) = sin(pi * x) * sin(pi * y)
         end do
-        
+
         error_adapt = compute_L2_interpolation_error(mesh_adapt, uh_adapt)
-        
+
         call check_condition(error_adapt < error_coarse, &
             "Adaptive refinement API: error decreases after refinement")
-        
+
         call plot(uh_adapt, filename="build/adaptive_refinement_solution.png", &
-                  title="Adaptive refinement solution")
-        
+            title="Adaptive refinement solution")
+
         write(*,*) "   Adaptive refinement API errors: coarse=", error_coarse, &
-                   " adapted=", error_adapt
+            " adapted=", error_adapt
     end subroutine test_adaptive_refinement_api
 
     ! Helper functions
@@ -718,72 +718,72 @@ contains
         real(dp) :: area
         integer :: v1, v2, v3
         real(dp) :: x1, y1, x2, y2, x3, y3
-        
+
         v1 = mesh%data%triangles(1, tri_idx)
         v2 = mesh%data%triangles(2, tri_idx)
         v3 = mesh%data%triangles(3, tri_idx)
-        
+
         x1 = mesh%data%vertices(1, v1)
         y1 = mesh%data%vertices(2, v1)
         x2 = mesh%data%vertices(1, v2)
         y2 = mesh%data%vertices(2, v2)
         x3 = mesh%data%vertices(1, v3)
         y3 = mesh%data%vertices(2, v3)
-        
+
         area = 0.5_dp * abs((x2-x1)*(y3-y1) - (x3-x1)*(y2-y1))
     end function compute_triangle_area
-    
+
     function triangle_contains_edge(mesh, tri_idx, v1, v2) result(contains_edge)
         type(mesh_t), intent(in) :: mesh
         integer, intent(in) :: tri_idx, v1, v2
         logical :: contains_edge
         integer :: tv1, tv2, tv3
-        
+
         tv1 = mesh%data%triangles(1, tri_idx)
         tv2 = mesh%data%triangles(2, tri_idx)
         tv3 = mesh%data%triangles(3, tri_idx)
-        
+
         contains_edge = ((tv1 == v1 .and. tv2 == v2) .or. &
-                       (tv1 == v2 .and. tv2 == v1) .or. &
-                       (tv2 == v1 .and. tv3 == v2) .or. &
-                       (tv2 == v2 .and. tv3 == v1) .or. &
-                       (tv3 == v1 .and. tv1 == v2) .or. &
-                       (tv3 == v2 .and. tv1 == v1))
+            (tv1 == v2 .and. tv2 == v1) .or. &
+            (tv2 == v1 .and. tv3 == v2) .or. &
+            (tv2 == v2 .and. tv3 == v1) .or. &
+            (tv3 == v1 .and. tv1 == v2) .or. &
+            (tv3 == v2 .and. tv1 == v1))
     end function triangle_contains_edge
-    
+
     function triangle_contains_edge_simple(mesh, tri_idx, v1, v2) result(contains)
         type(mesh_t), intent(in) :: mesh
         integer, intent(in) :: tri_idx, v1, v2
         logical :: contains
         integer :: tv1, tv2, tv3
-        
+
         tv1 = mesh%data%triangles(1, tri_idx)
         tv2 = mesh%data%triangles(2, tri_idx)
         tv3 = mesh%data%triangles(3, tri_idx)
-        
-        contains = ((tv1 == v1 .and. tv2 == v2) .or. (tv1 == v2 .and. tv2 == v1) .or. &
-                   (tv2 == v1 .and. tv3 == v2) .or. (tv2 == v2 .and. tv3 == v1) .or. &
-                   (tv3 == v1 .and. tv1 == v2) .or. (tv3 == v2 .and. tv1 == v1))
+
+    contains = ((tv1 == v1 .and. tv2 == v2) .or. (tv1 == v2 .and. tv2 == v1) .or. &
+            (tv2 == v1 .and. tv3 == v2) .or. (tv2 == v2 .and. tv3 == v1) .or. &
+            (tv3 == v1 .and. tv1 == v2) .or. (tv3 == v2 .and. tv1 == v1))
     end function triangle_contains_edge_simple
-    
+
     function compute_triangle_area_simple(mesh, tri_idx) result(area)
         type(mesh_t), intent(in) :: mesh
         integer, intent(in) :: tri_idx
         real(dp) :: area
         integer :: v1, v2, v3
         real(dp) :: x1, y1, x2, y2, x3, y3
-        
+
         v1 = mesh%data%triangles(1, tri_idx)
         v2 = mesh%data%triangles(2, tri_idx)
         v3 = mesh%data%triangles(3, tri_idx)
-        
+
         x1 = mesh%data%vertices(1, v1)
         y1 = mesh%data%vertices(2, v1)
         x2 = mesh%data%vertices(1, v2)
         y2 = mesh%data%vertices(2, v2)
         x3 = mesh%data%vertices(1, v3)
         y3 = mesh%data%vertices(2, v3)
-        
+
         area = 0.5_dp * abs((x2-x1)*(y3-y1) - (x3-x1)*(y2-y1))
     end function compute_triangle_area_simple
 

--- a/test/test_minimal_mesh_example.f90
+++ b/test/test_minimal_mesh_example.f90
@@ -5,14 +5,14 @@ program test_minimal_mesh_example
     implicit none
 
     integer :: test_count = 0, passed_tests = 0
-    
+
     write(*,*) "=== Minimal Mesh Example TDD Tests ==="
     write(*,*) ""
-    
+
     call test_simple_unit_square()
     call test_simple_triangle_boundary()
     call test_mesh_quality_basics()
-    
+
     ! Summary
     write(*,*) ""
     write(*,'(A,I0,A,I0)') "Tests passed: ", passed_tests, "/", test_count
@@ -22,162 +22,162 @@ program test_minimal_mesh_example
         write(*,*) "✗ Some tests failed!"
         stop 1
     end if
-    
+
 contains
 
     subroutine test_simple_unit_square()
         character(len=*), parameter :: test_name = "Simple Unit Square Mesh"
         type(mesh_t) :: mesh
-        
+
         call start_test(test_name)
-        
+
         ! Test the simplest possible case that must work
-        mesh = unit_square_mesh(5)  ! 5x5 grid, should always work
-        
+        mesh = unit_square_mesh(5) ! 5x5 grid, should always work
+
         write(*,'(A,I0)') "  Vertices: ", mesh%data%n_vertices
         write(*,'(A,I0)') "  Triangles: ", mesh%data%n_triangles
-        
+
         ! Basic validation - must pass for minimal example
         call assert_equal(mesh%data%n_vertices, 25, "5x5 = 25 vertices")
         call assert_equal(mesh%data%n_triangles, 32, "Expected triangle count")
         call assert_true(mesh%data%n_triangles > 0, "Has triangles")
         call assert_true(allocated(mesh%data%vertices), "Vertices allocated")
         call assert_true(allocated(mesh%data%triangles), "Triangles allocated")
-        
+
         ! Mesh bounds check
         call assert_bounds_valid(mesh, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp, "Unit square bounds")
-        
+
         ! Visual inspection output
         call plot(mesh, filename="build/minimal_unit_square_mesh.png")
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_simple_triangle_boundary()
         character(len=*), parameter :: test_name = "Simple Triangle Boundary"
         type(boundary_t) :: boundary
         type(mesh_t) :: mesh
-        
+
         call start_test(test_name)
-        
+
         ! Test simplest possible boundary case - equilateral triangle
         boundary = create_triangle_boundary()
-        
+
         ! This should work without edge validation issues
         ! (will skip complex validation for minimal example)
         write(*,'(A,I0)') "  Boundary points: ", boundary%n_points
         call assert_equal(boundary%n_points, 3, "Triangle has 3 points")
         call assert_true(boundary%is_closed, "Triangle boundary is closed")
-        
+
         ! For minimal example, we'll use simple rectangular mesh
         ! instead of complex triangulation to avoid validation issues
-        mesh = unit_square_mesh(3)  ! Simple fallback
+        mesh = unit_square_mesh(3) ! Simple fallback
         call assert_true(mesh%data%n_triangles > 0, "Fallback mesh works")
-        
+
         ! Visual inspection output
         call plot(mesh, filename="build/minimal_triangle_boundary_mesh.png")
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_mesh_quality_basics()
         character(len=*), parameter :: test_name = "Basic Mesh Quality Checks"
         type(mesh_t) :: mesh
         real(dp) :: min_area, max_area
-        
+
         call start_test(test_name)
-        
+
         mesh = unit_square_mesh(4)
-        
+
         ! Basic quality checks that minimal example must satisfy
         call compute_triangle_areas(mesh, min_area, max_area)
-        
+
         write(*,'(A,ES12.4)') "  Min triangle area: ", min_area
         write(*,'(A,ES12.4)') "  Max triangle area: ", max_area
-        
+
         call assert_true(min_area > 0.0_dp, "All triangles have positive area")
         call assert_true(max_area < 1.0_dp, "Triangle areas reasonable")
         call assert_true(max_area/min_area < 10.0_dp, "Area ratio reasonable")
-        
+
         call end_test()
     end subroutine
-    
+
     ! Helper functions
     function create_triangle_boundary() result(boundary)
         type(boundary_t) :: boundary
-        
+
         boundary%n_points = 3
         allocate(boundary%points(2, 3))
         allocate(boundary%labels(2))
-        
+
         ! Equilateral triangle
         boundary%points(:, 1) = [0.0_dp, 0.0_dp]
-        boundary%points(:, 2) = [1.0_dp, 0.0_dp]  
+        boundary%points(:, 2) = [1.0_dp, 0.0_dp]
         boundary%points(:, 3) = [0.5_dp, 0.866_dp]
-        
+
         boundary%labels = 1
         boundary%is_closed = .true.
     end function
-    
+
     subroutine assert_bounds_valid(mesh, x_min, x_max, y_min, y_max, description)
         type(mesh_t), intent(in) :: mesh
         real(dp), intent(in) :: x_min, x_max, y_min, y_max
         character(len=*), intent(in) :: description
-        
+
         real(dp) :: mesh_x_min, mesh_x_max, mesh_y_min, mesh_y_max
-        
+
         mesh_x_min = minval(mesh%data%vertices(1, :))
         mesh_x_max = maxval(mesh%data%vertices(1, :))
         mesh_y_min = minval(mesh%data%vertices(2, :))
         mesh_y_max = maxval(mesh%data%vertices(2, :))
-        
+
         call assert_true(abs(mesh_x_min - x_min) < 1e-10_dp, description // " x_min")
         call assert_true(abs(mesh_x_max - x_max) < 1e-10_dp, description // " x_max")
         call assert_true(abs(mesh_y_min - y_min) < 1e-10_dp, description // " y_min")
         call assert_true(abs(mesh_y_max - y_max) < 1e-10_dp, description // " y_max")
     end subroutine
-    
+
     subroutine compute_triangle_areas(mesh, min_area, max_area)
         type(mesh_t), intent(in) :: mesh
         real(dp), intent(out) :: min_area, max_area
-        
+
         integer :: i, v1, v2, v3
         real(dp) :: x1, y1, x2, y2, x3, y3, area
-        
+
         min_area = huge(1.0_dp)
         max_area = 0.0_dp
-        
+
         do i = 1, mesh%data%n_triangles
             v1 = mesh%data%triangles(1, i)
             v2 = mesh%data%triangles(2, i)
             v3 = mesh%data%triangles(3, i)
-            
+
             x1 = mesh%data%vertices(1, v1)
             y1 = mesh%data%vertices(2, v1)
             x2 = mesh%data%vertices(1, v2)
             y2 = mesh%data%vertices(2, v2)
             x3 = mesh%data%vertices(1, v3)
             y3 = mesh%data%vertices(2, v3)
-            
+
             area = 0.5_dp * abs((x1*(y2-y3) + x2*(y3-y1) + x3*(y1-y2)))
-            
+
             min_area = min(min_area, area)
             max_area = max(max_area, area)
         end do
     end subroutine
-    
+
     ! Test framework helpers
     subroutine start_test(test_name)
         character(len=*), intent(in) :: test_name
         test_count = test_count + 1
         write(*,'(A,I0,A,A)') "Test ", test_count, ": ", test_name
     end subroutine
-    
+
     subroutine end_test()
         passed_tests = passed_tests + 1
         write(*,*) "  ✓ PASSED"
     end subroutine
-    
+
     subroutine assert_equal(actual, expected, description)
         integer, intent(in) :: actual, expected
         character(len=*), intent(in) :: description
@@ -186,7 +186,7 @@ contains
             stop 1
         end if
     end subroutine
-    
+
     subroutine assert_true(condition, description)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: description

--- a/test/test_neumann_boundary_conditions.f90
+++ b/test/test_neumann_boundary_conditions.f90
@@ -5,14 +5,14 @@ program test_neumann_boundary_conditions
     implicit none
 
     write(*,*) "Testing Neumann boundary condition implementation..."
-    
+
     call test_neumann_bc_type_creation()
     call test_mixed_dirichlet_neumann_problem()
     call test_pure_neumann_problem()
     call test_neumann_boundary_integration()
     call test_convergence_with_neumann_bcs()
     call test_neumann_vs_analytical_solution()
-    
+
     call check_summary("Neumann Boundary Conditions")
 
 contains
@@ -23,21 +23,21 @@ contains
         type(function_space_t) :: Vh
         type(neumann_bc_t) :: neumann_bc
         real(dp) :: flux_value
-        
+
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Test Neumann BC creation with constant flux
         flux_value = 2.0_dp
         neumann_bc = neumann_bc_constant(Vh, flux_value)
-        
+
         call check_condition(associated(neumann_bc%space), &
             "Neumann BC: space pointer associated")
         call check_condition(neumann_bc%flux_type == "constant", &
             "Neumann BC: constant flux type")
         call check_condition(abs(neumann_bc%constant_value - flux_value) < 1.0e-14_dp, &
             "Neumann BC: correct constant value")
-        
+
         write(*,*) "   Neumann BC type creation tests passed"
     end subroutine test_neumann_bc_type_creation
 
@@ -52,40 +52,40 @@ contains
         type(neumann_bc_t) :: neumann_bc
         type(form_expr_t) :: a, L
         real(dp) :: solution_norm, max_val, boundary_flux
-        
+
         ! Mixed BC problem: -Δu = 1 in Ω, u = 0 on left edge, ∂u/∂n = 1 on right edge
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         ! Dirichlet BC: u = 0 on left boundary (x = 0)
         dirichlet_bc = dirichlet_bc_on_boundary(Vh, 0.0_dp, "left")
-        
+
         ! Neumann BC: ∂u/∂n = 1 on right boundary (x = 1)
         boundary_flux = 1.0_dp
         neumann_bc = neumann_bc_on_boundary(Vh, boundary_flux, "right")
-        
+
         uh = function(Vh)
-        
+
         ! Solve mixed BC problem
         call solve_mixed_bc(a == L, uh, dirichlet_bc, neumann_bc)
-        
+
         solution_norm = sqrt(sum(uh%values**2))
         max_val = maxval(uh%values)
-        
+
         call check_condition(solution_norm > 0.0_dp, &
             "Mixed BC: non-zero solution norm")
         call check_condition(max_val > 0.1_dp, &
             "Mixed BC: reasonable maximum value")
         call check_condition(max_val < 2.0_dp, &
             "Mixed BC: bounded solution")
-        
+
         write(*,*) "   Mixed boundary value problem tests passed"
         write(*,*) "   Solution norm:", solution_norm
         write(*,*) "   Maximum value:", max_val
@@ -102,38 +102,38 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: solution_norm, mean_value, total_flux, domain_area
         integer :: i
-        
+
         ! Pure Neumann problem: -Δu = f in Ω, ∂u/∂n = 0 on ∂Ω
         ! For compatibility: ∫_Ω f dx + ∫_∂Ω g ds = 0
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        domain_area = 1.0_dp  ! Unit square
-        
+        domain_area = 1.0_dp ! Unit square
+
         u = trial_function(Vh)
         v = test_function(Vh)
-        f = constant(0.0_dp)  ! Zero source to satisfy compatibility
-        
+        f = constant(0.0_dp) ! Zero source to satisfy compatibility
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         ! Neumann BC: ∂u/∂n = 0 on all boundaries (natural BC)
         neumann_bc = neumann_bc_constant(Vh, 0.0_dp)
-        
+
         uh = function(Vh)
-        
+
         ! Solve pure Neumann problem
         call solve_neumann(a == L, uh, neumann_bc)
-        
+
         solution_norm = sqrt(sum(uh%values**2))
-        
+
         ! Compute mean value (should be arbitrary constant)
         mean_value = sum(uh%values) / real(Vh%ndof, dp)
-        
+
         call check_condition(solution_norm >= 0.0_dp, &
             "Pure Neumann: non-negative solution norm")
         call check_condition(abs(mean_value) < 1.0e-6_dp .or. solution_norm < 1.0e-6_dp, &
             "Pure Neumann: solution unique up to constant")
-        
+
         write(*,*) "   Pure Neumann problem tests passed"
         write(*,*) "   Solution norm:", solution_norm
         write(*,*) "   Mean value:", mean_value
@@ -145,28 +145,28 @@ contains
         type(function_space_t) :: Vh
         type(neumann_bc_t) :: neumann_bc
         real(dp) :: boundary_integral, expected_integral, boundary_length
-        
+
         ! Test integration of Neumann BC over boundary
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Constant flux on boundary
         neumann_bc = neumann_bc_constant(Vh, 2.0_dp)
-        
+
         ! Compute boundary integral ∫_∂Ω g ds
         call compute_boundary_integral(neumann_bc, boundary_integral)
-        
+
         ! For unit square with constant flux g = 2: ∫_∂Ω 2 ds = 2 * perimeter = 2 * 4 = 8
-        boundary_length = 4.0_dp  ! Perimeter of unit square
+        boundary_length = 4.0_dp ! Perimeter of unit square
         expected_integral = 2.0_dp * boundary_length
-        
+
         call check_condition(abs(boundary_integral - expected_integral) < 0.1_dp, &
             "Boundary integration: correct integral value")
         call check_condition(boundary_integral > 7.0_dp, &
             "Boundary integration: reasonable lower bound")
         call check_condition(boundary_integral < 9.0_dp, &
             "Boundary integration: reasonable upper bound")
-        
+
         write(*,*) "   Boundary integration tests passed"
         write(*,*) "   Computed integral:", boundary_integral
         write(*,*) "   Expected integral:", expected_integral
@@ -185,39 +185,39 @@ contains
         real(dp) :: solution_norms(3), h_values(3)
         integer :: mesh_sizes(3), i
         logical :: convergence_ok
-        
+
         mesh_sizes = [3, 4, 5]
         h_values = 1.0_dp / real(mesh_sizes, dp)
-        
+
         ! Test convergence for mixed BC problem
         do i = 1, 3
             mesh = unit_square_mesh(mesh_sizes(i))
             Vh = function_space(mesh, "Lagrange", 1)
-            
+
             u = trial_function(Vh)
             v = test_function(Vh)
             f = constant(1.0_dp)
-            
+
             a = inner(grad(u), grad(v))*dx
             L = f*v*dx
-            
+
             dirichlet_bc = dirichlet_bc_on_boundary(Vh, 0.0_dp, "left")
             neumann_bc = neumann_bc_on_boundary(Vh, 1.0_dp, "right")
-            
+
             uh = function(Vh)
             call solve_mixed_bc(a == L, uh, dirichlet_bc, neumann_bc)
-            
+
             solution_norms(i) = sqrt(sum(uh%values**2))
         end do
-        
+
         ! Check that solutions exist and are reasonable
         convergence_ok = all(solution_norms > 0.01_dp) .and. all(solution_norms < 10.0_dp)
-        
+
         call check_condition(convergence_ok, &
             "Neumann convergence: solutions exist and bounded")
         call check_condition(solution_norms(3) > 0.5_dp * solution_norms(1), &
             "Neumann convergence: solution norms in reasonable range")
-        
+
         write(*,*) "   Convergence tests passed"
         write(*,*) "   Mesh sizes:", mesh_sizes
         write(*,*) "   Solution norms:", solution_norms
@@ -236,25 +236,25 @@ contains
         real(dp) :: max_error, l2_error, x, y, u_exact, u_computed
         integer :: i, center_node
         real(dp) :: min_dist, dist
-        
+
         ! Test against analytical solution u(x,y) = x² for -Δu = -2
         ! with u(0,y) = 0 (Dirichlet) and ∂u/∂n = 2 on x=1 (Neumann)
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
-        f = constant(-2.0_dp)  ! -Δ(x²) = -2
-        
+        f = constant(-2.0_dp) ! -Δ(x²) = -2
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
-        dirichlet_bc = dirichlet_bc_on_boundary(Vh, 0.0_dp, "left")   ! u = 0 at x = 0
-        neumann_bc = neumann_bc_on_boundary(Vh, 2.0_dp, "right")      ! ∂u/∂x = 2 at x = 1
-        
+
+        dirichlet_bc = dirichlet_bc_on_boundary(Vh, 0.0_dp, "left") ! u = 0 at x = 0
+        neumann_bc = neumann_bc_on_boundary(Vh, 2.0_dp, "right") ! ∂u/∂x = 2 at x = 1
+
         uh = function(Vh)
         call solve_mixed_bc(a == L, uh, dirichlet_bc, neumann_bc)
-        
+
         ! Compare with analytical solution at center point (0.5, 0.5)
         min_dist = huge(1.0_dp)
         center_node = 1
@@ -267,19 +267,19 @@ contains
                 center_node = i
             end if
         end do
-        
+
         x = Vh%mesh%data%vertices(1, center_node)
-        u_exact = x**2  ! Analytical solution
+        u_exact = x**2 ! Analytical solution
         u_computed = uh%values(center_node)
         max_error = abs(u_computed - u_exact)
-        
+
         call check_condition(max_error < 1.5_dp, &
             "Analytical comparison: reasonable error at center")
         call check_condition(u_computed > 0.1_dp, &
             "Analytical comparison: positive solution at center")
         call check_condition(u_computed < 2.0_dp, &
             "Analytical comparison: bounded solution at center")
-        
+
         write(*,*) "   Analytical solution tests passed"
         write(*,*) "   Center point (x,y):", x, Vh%mesh%data%vertices(2, center_node)
         write(*,*) "   Exact solution:", u_exact

--- a/test/test_p2_basis_functions.f90
+++ b/test/test_p2_basis_functions.f90
@@ -5,13 +5,13 @@ program test_p2_basis_functions
     implicit none
 
     write(*,*) "Testing P2 basis function properties..."
-    
+
     call test_p2_basis_evaluation()
     call test_p2_basis_gradients()
     call test_p2_partition_of_unity()
     call test_p2_lagrange_property()
     call test_p2_hessian_computation()
-    
+
     call check_summary("P2 Basis Functions")
 
 contains
@@ -20,40 +20,40 @@ contains
     subroutine test_p2_basis_evaluation()
         type(basis_p2_2d_t) :: basis
         real(dp) :: val
-        
+
         ! Test vertex basis functions at vertices
         ! φ₁(0,0) = 1, φ₁ at other vertices = 0
         val = basis%eval(1, 0.0_dp, 0.0_dp)
         call check_condition(abs(val - 1.0_dp) < 1.0e-14_dp, &
             "P2 evaluation: φ₁(0,0) = 1")
-        
+
         val = basis%eval(1, 1.0_dp, 0.0_dp)
         call check_condition(abs(val - 0.0_dp) < 1.0e-14_dp, &
             "P2 evaluation: φ₁(1,0) = 0")
-        
+
         val = basis%eval(1, 0.0_dp, 1.0_dp)
         call check_condition(abs(val - 0.0_dp) < 1.0e-14_dp, &
             "P2 evaluation: φ₁(0,1) = 0")
-        
+
         ! φ₂(1,0) = 1, φ₂ at other vertices = 0
         val = basis%eval(2, 1.0_dp, 0.0_dp)
         call check_condition(abs(val - 1.0_dp) < 1.0e-14_dp, &
             "P2 evaluation: φ₂(1,0) = 1")
-        
+
         val = basis%eval(2, 0.0_dp, 0.0_dp)
         call check_condition(abs(val - 0.0_dp) < 1.0e-14_dp, &
             "P2 evaluation: φ₂(0,0) = 0")
-        
+
         ! Test edge basis functions at edge midpoints
         ! φ₄(0.5,0) = 1 (edge 1-2 midpoint)
         val = basis%eval(4, 0.5_dp, 0.0_dp)
         call check_condition(abs(val - 1.0_dp) < 1.0e-14_dp, &
             "P2 evaluation: φ₄(0.5,0) = 1")
-        
+
         val = basis%eval(4, 0.0_dp, 0.0_dp)
         call check_condition(abs(val - 0.0_dp) < 1.0e-14_dp, &
             "P2 evaluation: φ₄(0,0) = 0")
-        
+
         write(*,*) "   P2 basis evaluation tests passed"
     end subroutine test_p2_basis_evaluation
 
@@ -61,29 +61,29 @@ contains
     subroutine test_p2_basis_gradients()
         type(basis_p2_2d_t) :: basis
         real(dp) :: grad(2), expected_grad(2)
-        
+
         ! Test gradient of φ₁ at center
         grad = basis%grad(1, 1.0_dp/3.0_dp, 1.0_dp/3.0_dp)
         ! At center, λ₁ = λ₂ = λ₃ = 1/3
         ! φ₁ = λ₁(2λ₁ - 1) = (1/3)(2/3 - 1) = (1/3)(-1/3) = -1/9
         ! ∇φ₁ = (4λ₁ - 1)∇λ₁ = (4/3 - 1)[-1, -1] = (1/3)[-1, -1] = [-1/3, -1/3]
         expected_grad = [-1.0_dp/3.0_dp, -1.0_dp/3.0_dp]
-        
+
         call check_condition(abs(grad(1) - expected_grad(1)) < 1.0e-12_dp, &
             "P2 gradients: φ₁ x-gradient at center")
         call check_condition(abs(grad(2) - expected_grad(2)) < 1.0e-12_dp, &
             "P2 gradients: φ₁ y-gradient at center")
-        
+
         ! Test gradient of φ₂ at center
         grad = basis%grad(2, 1.0_dp/3.0_dp, 1.0_dp/3.0_dp)
         ! ∇φ₂ = (4λ₂ - 1)∇λ₂ = (1/3)[1, 0] = [1/3, 0]
         expected_grad = [1.0_dp/3.0_dp, 0.0_dp]
-        
+
         call check_condition(abs(grad(1) - expected_grad(1)) < 1.0e-12_dp, &
             "P2 gradients: φ₂ x-gradient at center")
         call check_condition(abs(grad(2) - expected_grad(2)) < 1.0e-12_dp, &
             "P2 gradients: φ₂ y-gradient at center")
-        
+
         write(*,*) "   P2 gradient computation tests passed"
     end subroutine test_p2_basis_gradients
 
@@ -92,25 +92,25 @@ contains
         type(basis_p2_2d_t) :: basis
         real(dp) :: xi, eta, sum_basis
         integer :: i, j, k
-        
+
         ! Test at several points that sum of basis functions = 1
         do i = 0, 5
             do j = 0, 5-i
                 xi = real(i, dp) / 5.0_dp
                 eta = real(j, dp) / 5.0_dp
-                
+
                 if (xi + eta <= 1.0_dp) then
                     sum_basis = 0.0_dp
                     do k = 1, 6
                         sum_basis = sum_basis + basis%eval(k, xi, eta)
                     end do
-                    
+
                     call check_condition(abs(sum_basis - 1.0_dp) < 1.0e-14_dp, &
                         "P2 partition of unity: sum = 1")
                 end if
             end do
         end do
-        
+
         write(*,*) "   P2 partition of unity tests passed"
     end subroutine test_p2_partition_of_unity
 
@@ -120,15 +120,15 @@ contains
         real(dp) :: nodes(2,6)
         real(dp) :: val
         integer :: i, j
-        
+
         ! P2 nodes: vertices + edge midpoints
-        nodes(:,1) = [0.0_dp, 0.0_dp]  ! Vertex 1
-        nodes(:,2) = [1.0_dp, 0.0_dp]  ! Vertex 2
-        nodes(:,3) = [0.0_dp, 1.0_dp]  ! Vertex 3
-        nodes(:,4) = [0.5_dp, 0.0_dp]  ! Edge 1-2 midpoint
-        nodes(:,5) = [0.5_dp, 0.5_dp]  ! Edge 2-3 midpoint
-        nodes(:,6) = [0.0_dp, 0.5_dp]  ! Edge 3-1 midpoint
-        
+        nodes(:,1) = [0.0_dp, 0.0_dp] ! Vertex 1
+        nodes(:,2) = [1.0_dp, 0.0_dp] ! Vertex 2
+        nodes(:,3) = [0.0_dp, 1.0_dp] ! Vertex 3
+        nodes(:,4) = [0.5_dp, 0.0_dp] ! Edge 1-2 midpoint
+        nodes(:,5) = [0.5_dp, 0.5_dp] ! Edge 2-3 midpoint
+        nodes(:,6) = [0.0_dp, 0.5_dp] ! Edge 3-1 midpoint
+
         do i = 1, 6
             do j = 1, 6
                 val = basis%eval(i, nodes(1,j), nodes(2,j))
@@ -141,7 +141,7 @@ contains
                 end if
             end do
         end do
-        
+
         write(*,*) "   P2 Lagrange property tests passed"
     end subroutine test_p2_lagrange_property
 
@@ -149,10 +149,10 @@ contains
     subroutine test_p2_hessian_computation()
         type(basis_p2_2d_t) :: basis
         real(dp) :: hess(2,2)
-        
+
         ! Test Hessian of φ₁ at a point
         hess = basis%hessian(1, 0.2_dp, 0.3_dp)
-        
+
         ! For φ₁ = λ₁(2λ₁ - 1), the Hessian should be constant
         ! Since λ₁ = 1 - ξ - η, we have ∇²φ₁ = 4∇λ₁ ⊗ ∇λ₁
         call check_condition(abs(hess(1,1) - 4.0_dp) < 1.0e-14_dp, &
@@ -161,7 +161,7 @@ contains
             "P2 Hessian: φ₁ ∂²/∂ξ∂η")
         call check_condition(abs(hess(2,2) - 4.0_dp) < 1.0e-14_dp, &
             "P2 Hessian: φ₁ ∂²/∂η²")
-        
+
         write(*,*) "   P2 Hessian computation tests passed"
     end subroutine test_p2_hessian_computation
 

--- a/test/test_p2_lagrange_elements.f90
+++ b/test/test_p2_lagrange_elements.f90
@@ -5,14 +5,14 @@ program test_p2_lagrange_elements
     implicit none
 
     write(*,*) "Testing P2 Lagrange element implementation..."
-    
+
     call test_p2_basis_functions()
     call test_p2_function_space_creation()
     call test_p2_dof_mapping()
     call test_p2_element_matrix_assembly()
     call test_p2_convergence_properties()
     call test_p2_vs_p1_comparison()
-    
+
     call check_summary("P2 Lagrange Elements")
 
 contains
@@ -23,23 +23,23 @@ contains
         type(function_space_t) :: Vh
         real(dp) :: xi, eta, val, expected
         integer :: i
-        
+
         ! Test P2 function space creation
         mesh = unit_square_mesh(3)
         Vh = function_space(mesh, "Lagrange", 2)
-        
+
         call check_condition(Vh%degree == 2, &
             "P2 basis: correct degree")
         call check_condition(trim(Vh%element_family) == "Lagrange", &
             "P2 basis: correct element family")
         call check_condition(Vh%ndof > mesh%data%n_vertices, &
             "P2 basis: more DOFs than vertices")
-        
-        ! Expected DOFs for P2: vertices + edge midpoints  
+
+        ! Expected DOFs for P2: vertices + edge midpoints
         ! For triangular mesh: n_vertices + n_edges
         call check_condition(Vh%ndof == mesh%data%n_vertices + mesh%data%n_edges, &
             "P2 basis: correct DOF count")
-        
+
         write(*,*) "   P2 mesh vertices:", mesh%data%n_vertices
         write(*,*) "   P2 mesh edges:", mesh%data%n_edges
         write(*,*) "   P2 total DOFs:", Vh%ndof
@@ -50,14 +50,14 @@ contains
         type(mesh_t) :: mesh
         type(function_space_t) :: Vh_p1, Vh_p2
         integer :: n_values(3), i
-        
+
         n_values = [3, 5, 7]
-        
+
         do i = 1, 3
             mesh = unit_square_mesh(n_values(i))
             Vh_p1 = function_space(mesh, "Lagrange", 1)
             Vh_p2 = function_space(mesh, "Lagrange", 2)
-            
+
             call check_condition(Vh_p2%ndof > Vh_p1%ndof, &
                 "P2 function space: more DOFs than P1")
             call check_condition(Vh_p2%degree == 2, &
@@ -65,7 +65,7 @@ contains
             call check_condition(Vh_p1%degree == 1, &
                 "P1 function space: correct degree")
         end do
-        
+
         write(*,*) "   P2 function spaces created successfully"
     end subroutine test_p2_function_space_creation
 
@@ -75,32 +75,32 @@ contains
         type(function_space_t) :: Vh
         type(function_t) :: uh
         integer :: i, vertex_dofs, edge_dofs
-        
+
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 2)
         uh = function(Vh)
-        
+
         call check_condition(allocated(uh%values), &
             "P2 DOF mapping: function values allocated")
         call check_condition(size(uh%values) == Vh%ndof, &
             "P2 DOF mapping: correct values array size")
-        
+
         ! Test that we can set and retrieve DOF values
         do i = 1, Vh%ndof
             uh%values(i) = real(i, dp)
         end do
-        
+
         call check_condition(uh%values(1) == 1.0_dp, &
             "P2 DOF mapping: can set/get first DOF")
         call check_condition(uh%values(Vh%ndof) == real(Vh%ndof, dp), &
             "P2 DOF mapping: can set/get last DOF")
-        
+
         vertex_dofs = mesh%data%n_vertices
         edge_dofs = mesh%data%n_edges
-        
+
         call check_condition(vertex_dofs + edge_dofs == Vh%ndof, &
             "P2 DOF mapping: vertex + edge DOFs equal total")
-        
+
         write(*,*) "   P2 vertex DOFs:", vertex_dofs
         write(*,*) "   P2 edge DOFs:", edge_dofs
         write(*,*) "   P2 total DOFs:", Vh%ndof
@@ -116,33 +116,33 @@ contains
         type(dirichlet_bc_t) :: bc
         type(form_expr_t) :: a, L
         real(dp) :: solution_norm, max_val
-        
+
         ! Test P2 problem assembly and solution
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 2)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         solution_norm = sqrt(sum(uh%values**2))
         max_val = maxval(uh%values)
-        
+
         call check_condition(solution_norm > 0.0_dp, &
             "P2 assembly: non-zero solution norm")
         call check_condition(max_val > 0.01_dp, &
             "P2 assembly: reasonable maximum value")
         call check_condition(max_val < 1.0_dp, &
             "P2 assembly: bounded solution")
-        
+
         write(*,*) "   P2 solution norm:", solution_norm
         write(*,*) "   P2 maximum value:", max_val
         write(*,*) "   P2 total DOFs:", Vh%ndof
@@ -159,29 +159,29 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: max_vals(3), h_vals(3)
         integer :: n_vals(3), i
-        
+
         ! Test convergence on sequence of P2 meshes
         n_vals = [3, 4, 5]
         h_vals = 1.0_dp / real(n_vals, dp)
-        
+
         do i = 1, 3
             mesh = unit_square_mesh(n_vals(i))
             Vh = function_space(mesh, "Lagrange", 2)
-            
+
             u = trial_function(Vh)
             v = test_function(Vh)
             f = constant(1.0_dp)
-            
+
             a = inner(grad(u), grad(v))*dx
             L = f*v*dx
-            
+
             bc = dirichlet_bc(Vh, 0.0_dp)
             uh = function(Vh)
-            
+
             call solve(a == L, uh, bc)
             max_vals(i) = maxval(uh%values)
         end do
-        
+
         ! For this problem, max values should converge monotonically
         ! Check that values are decreasing (converging to true solution)
         call check_condition(max_vals(2) < max_vals(1) * 1.1_dp, &
@@ -190,7 +190,7 @@ contains
             "P2 convergence: refinement 2 shows convergence")
         call check_condition(all(max_vals > 0.01_dp), &
             "P2 convergence: all solutions positive")
-        
+
         write(*,*) "   P2 mesh sizes:", n_vals
         write(*,*) "   P2 max values:", max_vals
         write(*,*) "   P2 h values:", h_vals
@@ -206,48 +206,48 @@ contains
         type(dirichlet_bc_t) :: bc1, bc2
         type(form_expr_t) :: a1, L1, a2, L2
         real(dp) :: max_p1, max_p2, norm_p1, norm_p2
-        
+
         ! Compare P1 vs P2 on same mesh
         mesh = unit_square_mesh(5)
-        
+
         ! P1 solution
         Vh_p1 = function_space(mesh, "Lagrange", 1)
         u1 = trial_function(Vh_p1)
         v1 = test_function(Vh_p1)
         f = constant(1.0_dp)
-        
+
         a1 = inner(grad(u1), grad(v1))*dx
         L1 = f*v1*dx
-        
+
         bc1 = dirichlet_bc(Vh_p1, 0.0_dp)
         uh1 = function(Vh_p1)
         call solve(a1 == L1, uh1, bc1)
-        
+
         max_p1 = maxval(uh1%values)
         norm_p1 = sqrt(sum(uh1%values**2))
-        
+
         ! P2 solution
         Vh_p2 = function_space(mesh, "Lagrange", 2)
         u2 = trial_function(Vh_p2)
         v2 = test_function(Vh_p2)
-        
+
         a2 = inner(grad(u2), grad(v2))*dx
         L2 = f*v2*dx
-        
+
         bc2 = dirichlet_bc(Vh_p2, 0.0_dp)
         uh2 = function(Vh_p2)
         call solve(a2 == L2, uh2, bc2)
-        
+
         max_p2 = maxval(uh2%values)
         norm_p2 = sqrt(sum(uh2%values**2))
-        
+
         call check_condition(Vh_p2%ndof > Vh_p1%ndof, &
             "P2 vs P1: P2 has more DOFs")
         call check_condition(max_p2 > 0.5_dp * max_p1, &
             "P2 vs P1: P2 maximum comparable to P1")
         call check_condition(norm_p2 > 0.5_dp * norm_p1, &
             "P2 vs P1: P2 norm reasonable compared to P1")
-        
+
         write(*,*) "   P1 DOFs:", Vh_p1%ndof, "max:", max_p1, "norm:", norm_p1
         write(*,*) "   P2 DOFs:", Vh_p2%ndof, "max:", max_p2, "norm:", norm_p2
         write(*,*) "   DOF ratio (P2/P1):", real(Vh_p2%ndof) / real(Vh_p1%ndof)

--- a/test/test_point_location.f90
+++ b/test/test_point_location.f90
@@ -77,7 +77,7 @@ contains
         call locate_point(mesh, 0.25_dp, 0.25_dp, tri_idx, loc_type)
         call check_condition(tri_idx > 0, "Inside: lower-left point found")
         call check_condition(loc_type == LOCATION_INSIDE .or.                    &
-                            loc_type == LOCATION_ON_EDGE,                        &
+            loc_type == LOCATION_ON_EDGE,                        &
             "Inside: lower-left location type correct")
 
         ! Point in upper-right region
@@ -166,7 +166,7 @@ contains
             call locate_point(mesh, px, py, tri_idx_walk, loc_type_walk)
 
             call locate_point_linear_test(mesh, px, py, tri_idx_linear,          &
-                                         loc_type_linear)
+                loc_type_linear)
 
             n_tests = n_tests + 1
             ! Both should find some triangle (walking may find different one

--- a/test/test_poisson_quads.f90
+++ b/test/test_poisson_quads.f90
@@ -163,7 +163,7 @@ contains
         call solve(a_q == L_q, uh_q, bc_q)
 
         call plot(uh_q, filename="build/poisson_quads_solution.png", &
-                  title="Poisson solution on Q1 quadrilateral mesh")
+            title="Poisson solution on Q1 quadrilateral mesh")
 
         call check_condition(any(uh_q%values /= 0.0_dp), &
             "Quad Poisson plot: non-trivial solution plotted")

--- a/test/test_quadrilateral_elements.f90
+++ b/test/test_quadrilateral_elements.f90
@@ -2,7 +2,7 @@ program test_quadrilateral_elements
     use fortfem_kinds
     use fortfem_api
     use basis_q1_quad_2d_module, only: q1_shape_functions, q1_shape_derivatives, &
-                                        q1_jacobian, q1_reference_to_physical
+        q1_jacobian, q1_reference_to_physical
     use check
     implicit none
 
@@ -15,7 +15,7 @@ program test_quadrilateral_elements
     end interface
 
     write(*,*) "Testing quadrilateral element implementation..."
-    
+
     call test_q1_shape_functions()
     call test_q1_derivatives()
     call test_q1_jacobian_mapping()
@@ -27,7 +27,7 @@ program test_quadrilateral_elements
     call test_q1_convergence_rates()
     call test_q1_performance()
     call test_q1_solution_plot()
-    
+
     call check_summary("Quadrilateral Elements")
 
 contains
@@ -37,7 +37,7 @@ contains
         real(dp) :: xi, eta, N(4)
         real(dp) :: tolerance = 1.0e-12_dp
         integer :: i
-        
+
         ! Test shape functions at nodes
         ! Node 1: (-1,-1)
         call q1_shape_functions(-1.0_dp, -1.0_dp, N)
@@ -49,7 +49,7 @@ contains
             "Q1 shape: N3(-1,-1) = 0")
         call check_condition(abs(N(4)) < tolerance, &
             "Q1 shape: N4(-1,-1) = 0")
-        
+
         ! Node 2: (1,-1)
         call q1_shape_functions(1.0_dp, -1.0_dp, N)
         call check_condition(abs(N(1)) < tolerance, &
@@ -60,7 +60,7 @@ contains
             "Q1 shape: N3(1,-1) = 0")
         call check_condition(abs(N(4)) < tolerance, &
             "Q1 shape: N4(1,-1) = 0")
-        
+
         ! Node 3: (1,1)
         call q1_shape_functions(1.0_dp, 1.0_dp, N)
         call check_condition(abs(N(1)) < tolerance, &
@@ -71,7 +71,7 @@ contains
             "Q1 shape: N3(1,1) = 1")
         call check_condition(abs(N(4)) < tolerance, &
             "Q1 shape: N4(1,1) = 0")
-        
+
         ! Node 4: (-1,1)
         call q1_shape_functions(-1.0_dp, 1.0_dp, N)
         call check_condition(abs(N(1)) < tolerance, &
@@ -82,17 +82,17 @@ contains
             "Q1 shape: N3(-1,1) = 0")
         call check_condition(abs(N(4) - 1.0_dp) < tolerance, &
             "Q1 shape: N4(-1,1) = 1")
-        
+
         ! Test partition of unity at center
         call q1_shape_functions(0.0_dp, 0.0_dp, N)
         call check_condition(abs(sum(N) - 1.0_dp) < tolerance, &
             "Q1 shape: partition of unity at center")
-        
+
         ! Test partition of unity at arbitrary point
         call q1_shape_functions(0.3_dp, -0.7_dp, N)
         call check_condition(abs(sum(N) - 1.0_dp) < tolerance, &
             "Q1 shape: partition of unity at (0.3,-0.7)")
-        
+
         write(*,*) "   Q1 shape functions: all tests passed"
     end subroutine test_q1_shape_functions
 
@@ -100,16 +100,16 @@ contains
     subroutine test_q1_derivatives()
         real(dp) :: xi, eta, dN_dxi(4), dN_deta(4)
         real(dp) :: tolerance = 1.0e-12_dp
-        
+
         ! Test derivatives at center
         call q1_shape_derivatives(0.0_dp, 0.0_dp, dN_dxi, dN_deta)
-        
+
         ! Sum of derivatives should be zero (constant preservation)
         call check_condition(abs(sum(dN_dxi)) < tolerance, &
             "Q1 derivatives: sum dN/dxi = 0")
         call check_condition(abs(sum(dN_deta)) < tolerance, &
             "Q1 derivatives: sum dN/deta = 0")
-        
+
         ! Test specific values at center
         call check_condition(abs(dN_dxi(1) + 0.25_dp) < tolerance, &
             "Q1 derivatives: dN1/dxi at center")
@@ -119,28 +119,28 @@ contains
             "Q1 derivatives: dN1/deta at center")
         call check_condition(abs(dN_deta(4) - 0.25_dp) < tolerance, &
             "Q1 derivatives: dN4/deta at center")
-        
+
         ! Test derivatives at corner
         call q1_shape_derivatives(-1.0_dp, -1.0_dp, dN_dxi, dN_deta)
         call check_condition(abs(dN_dxi(1) + 0.5_dp) < tolerance, &
             "Q1 derivatives: dN1/dxi at (-1,-1)")
         call check_condition(abs(dN_deta(1) + 0.5_dp) < tolerance, &
             "Q1 derivatives: dN1/deta at (-1,-1)")
-        
+
         write(*,*) "   Q1 derivatives: all tests passed"
     end subroutine test_q1_derivatives
 
     ! Test isoparametric mapping and Jacobian computation
     subroutine test_q1_jacobian_mapping()
-        real(dp) :: coords(2,4)  ! Physical coordinates of quad nodes
+        real(dp) :: coords(2,4) ! Physical coordinates of quad nodes
         real(dp) :: xi, eta, jac(2,2), det_jac, inv_jac(2,2)
         real(dp) :: tolerance = 1.0e-12_dp
         logical :: success
-        
+
         ! Unit square quadrilateral
-        coords(1,:) = [0.0_dp, 1.0_dp, 1.0_dp, 0.0_dp]  ! x-coordinates
-        coords(2,:) = [0.0_dp, 0.0_dp, 1.0_dp, 1.0_dp]  ! y-coordinates
-        
+        coords(1,:) = [0.0_dp, 1.0_dp, 1.0_dp, 0.0_dp] ! x-coordinates
+        coords(2,:) = [0.0_dp, 0.0_dp, 1.0_dp, 1.0_dp] ! y-coordinates
+
         ! Test Jacobian at center
         call q1_jacobian(0.0_dp, 0.0_dp, coords, jac, det_jac, inv_jac, success)
         call check_condition(success, "Q1 Jacobian: computation successful")
@@ -154,21 +154,21 @@ contains
             "Q1 Jacobian: dx/deta = 0")
         call check_condition(abs(jac(2,1)) < tolerance, &
             "Q1 Jacobian: dy/dxi = 0")
-        
+
         ! Test mapping from reference to physical
         call q1_reference_to_physical(0.0_dp, 0.0_dp, coords, xi, eta)
         call check_condition(abs(xi - 0.5_dp) < tolerance .and. &
-                           abs(eta - 0.5_dp) < tolerance, &
+            abs(eta - 0.5_dp) < tolerance, &
             "Q1 mapping: center maps to (0.5,0.5)")
-        
+
         ! Stretched rectangle
-        coords(1,:) = [0.0_dp, 2.0_dp, 2.0_dp, 0.0_dp]  ! x-coordinates
-        coords(2,:) = [0.0_dp, 0.0_dp, 3.0_dp, 3.0_dp]  ! y-coordinates
-        
+        coords(1,:) = [0.0_dp, 2.0_dp, 2.0_dp, 0.0_dp] ! x-coordinates
+        coords(2,:) = [0.0_dp, 0.0_dp, 3.0_dp, 3.0_dp] ! y-coordinates
+
         call q1_jacobian(0.0_dp, 0.0_dp, coords, jac, det_jac, inv_jac, success)
         call check_condition(abs(det_jac - 1.5_dp) < tolerance, &
             "Q1 Jacobian: stretched rectangle det = 1.5")
-        
+
         write(*,*) "   Q1 Jacobian mapping: all tests passed"
     end subroutine test_q1_jacobian_mapping
 
@@ -176,39 +176,39 @@ contains
     subroutine test_q1_quadrature_integration()
         real(dp) :: coords(2,4), integral_exact, integral_computed
         real(dp) :: tolerance = 1.0e-12_dp
-        integer :: nq = 2  ! 2x2 Gauss quadrature
-        
+        integer :: nq = 2 ! 2x2 Gauss quadrature
+
         ! Unit square
         coords(1,:) = [0.0_dp, 1.0_dp, 1.0_dp, 0.0_dp]
         coords(2,:) = [0.0_dp, 0.0_dp, 1.0_dp, 1.0_dp]
-        
+
         ! Integrate constant function f = 1
         integral_computed = integrate_over_quad(constant_function, coords, nq)
-        integral_exact = 1.0_dp  ! Area of unit square
+        integral_exact = 1.0_dp ! Area of unit square
         call check_condition(abs(integral_computed - integral_exact) < tolerance, &
             "Q1 quadrature: constant function")
-        
+
         ! Integrate linear function f = x + y
         integral_computed = integrate_over_quad(linear_function, coords, nq)
-        integral_exact = 1.0_dp  ! ∫∫(x+y)dxdy over [0,1]²
+        integral_exact = 1.0_dp ! ∫∫(x+y)dxdy over [0,1]²
         call check_condition(abs(integral_computed - integral_exact) < tolerance, &
             "Q1 quadrature: linear function")
-        
+
         ! Integrate bilinear function f = xy
         integral_computed = integrate_over_quad(bilinear_function, coords, nq)
-        integral_exact = 0.25_dp  ! ∫∫xy dxdy over [0,1]²
+        integral_exact = 0.25_dp ! ∫∫xy dxdy over [0,1]²
         call check_condition(abs(integral_computed - integral_exact) < tolerance, &
             "Q1 quadrature: bilinear function")
-        
+
         ! Scaled rectangle
         coords(1,:) = [0.0_dp, 2.0_dp, 2.0_dp, 0.0_dp]
         coords(2,:) = [0.0_dp, 0.0_dp, 1.0_dp, 1.0_dp]
-        
+
         integral_computed = integrate_over_quad(constant_function, coords, nq)
-        integral_exact = 2.0_dp  ! Area = 2×1
+        integral_exact = 2.0_dp ! Area = 2×1
         call check_condition(abs(integral_computed - integral_exact) < tolerance, &
             "Q1 quadrature: scaled rectangle")
-        
+
         write(*,*) "   Q1 quadrature integration: all tests passed"
     end subroutine test_q1_quadrature_integration
 
@@ -216,30 +216,30 @@ contains
     subroutine test_quad_mesh_creation()
         type(mesh_t) :: quad_mesh
         integer :: expected_vertices, expected_quads
-        
+
         ! Create 2x2 structured quad mesh
         quad_mesh = structured_quad_mesh(2, 2, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
-        
-        expected_vertices = 9  ! (2+1) × (2+1)
-        expected_quads = 4     ! 2 × 2
-        
+
+        expected_vertices = 9 ! (2+1) × (2+1)
+        expected_quads = 4 ! 2 × 2
+
         call check_condition(quad_mesh%data%n_vertices == expected_vertices, &
             "Quad mesh: correct vertex count")
         call check_condition(quad_mesh%data%n_quads == expected_quads, &
             "Quad mesh: correct quad count")
         call check_condition(quad_mesh%data%has_quads, &
             "Quad mesh: quad flag set")
-        
+
         ! Check mesh connectivity
         call check_condition(quad_mesh%data%n_edges > 0, &
             "Quad mesh: edges built")
         call check_condition(count(quad_mesh%data%is_boundary_vertex) > 0, &
             "Quad mesh: boundary vertices identified")
-        
+
         ! Verify mesh quality
         call check_condition(compute_quad_mesh_quality(quad_mesh) > 0.8_dp, &
             "Quad mesh: good quality metrics")
-        
+
         write(*,*) "   Structured quad mesh creation: all tests passed"
     end subroutine test_quad_mesh_creation
 
@@ -248,32 +248,32 @@ contains
         type(mesh_t) :: mixed_mesh
         type(function_space_t) :: Vh_mixed
         integer :: total_elements, total_dofs
-        
+
         ! Create mesh with both triangles and quads
         mixed_mesh = mixed_tri_quad_mesh()
-        
+
         call check_condition(mixed_mesh%data%n_triangles > 0, &
             "Mixed mesh: has triangles")
         call check_condition(mixed_mesh%data%n_quads > 0, &
             "Mixed mesh: has quadrilaterals")
         call check_condition(mixed_mesh%data%has_mixed_elements, &
             "Mixed mesh: mixed element flag set")
-        
+
         total_elements = mixed_mesh%data%n_triangles + mixed_mesh%data%n_quads
         call check_condition(total_elements > 0, &
             "Mixed mesh: positive element count")
-        
+
         ! Test function space on mixed mesh
         Vh_mixed = function_space(mixed_mesh, "Lagrange", 1)
         total_dofs = Vh_mixed%ndof
-        
+
         call check_condition(total_dofs == mixed_mesh%data%n_vertices, &
             "Mixed mesh: correct P1 DOF count")
         call check_condition(trim(Vh_mixed%element_family) == "Lagrange", &
             "Mixed mesh: correct element family")
         call check_condition(Vh_mixed%degree == 1, &
             "Mixed mesh: correct degree")
-        
+
         write(*,*) "   Mixed element mesh: all tests passed"
     end subroutine test_mixed_element_mesh
 
@@ -281,24 +281,24 @@ contains
     subroutine test_q1_assembly_system()
         type(mesh_t) :: quad_mesh
         type(function_space_t) :: Vh
-        
+
         ! Create simple quad mesh
         quad_mesh = structured_quad_mesh(2, 2, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
         Vh = function_space(quad_mesh, "Lagrange", 1)
-        
+
         call check_condition(Vh%ndof > 0, &
             "Q1 assembly: positive DOF count")
         call check_condition(trim(Vh%element_family) == "Lagrange", &
             "Q1 assembly: correct element family")
         call check_condition(Vh%degree == 1, &
             "Q1 assembly: correct degree")
-        
+
         ! Check that mesh has quadrilaterals
         call check_condition(quad_mesh%data%has_quads, &
             "Q1 assembly: mesh has quadrilaterals")
         call check_condition(quad_mesh%data%n_quads > 0, &
             "Q1 assembly: positive quad count")
-        
+
         write(*,*) "   Q1 assembly system: all tests passed"
     end subroutine test_q1_assembly_system
 
@@ -309,32 +309,32 @@ contains
         type(function_t) :: uh
         type(dirichlet_bc_t) :: bc
         integer :: boundary_dofs, interior_dofs
-        
+
         quad_mesh = structured_quad_mesh(3, 3, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
         Vh = function_space(quad_mesh, "Lagrange", 1)
-        
+
         ! Test zero Dirichlet BC
         bc = dirichlet_bc(Vh, 0.0_dp)
         call check_condition(abs(bc%value) < 1.0e-12_dp, &
             "Q1 BC: zero boundary value")
         call check_condition(bc%on_boundary, &
             "Q1 BC: boundary flag set")
-        
+
         boundary_dofs = count(quad_mesh%data%is_boundary_vertex)
         interior_dofs = Vh%ndof - boundary_dofs
-        
+
         call check_condition(boundary_dofs > 0, &
             "Q1 BC: positive boundary DOF count")
         call check_condition(interior_dofs > 0, &
             "Q1 BC: positive interior DOF count")
         call check_condition(boundary_dofs + interior_dofs == Vh%ndof, &
             "Q1 BC: DOF count consistency")
-        
+
         ! Test non-zero Dirichlet BC
         bc = dirichlet_bc(Vh, 1.0_dp)
         call check_condition(abs(bc%value - 1.0_dp) < 1.0e-12_dp, &
             "Q1 BC: constant boundary value")
-        
+
         ! Test function with boundary conditions
         uh = function(Vh)
         if (allocated(uh%values)) then
@@ -342,7 +342,7 @@ contains
         end if
         call check_condition(allocated(uh%values), &
             "Q1 BC: function values allocated")
-        
+
         write(*,*) "   Q1 boundary conditions: all tests passed"
     end subroutine test_q1_boundary_conditions
 
@@ -353,34 +353,34 @@ contains
         type(function_t) :: uh1, uh2, uh3
         real(dp) :: errors(3), h_values(3), convergence_rate
         real(dp) :: tolerance = 0.1_dp
-        
+
         ! Create sequence of refined quad meshes
         mesh1 = structured_quad_mesh(2, 2, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
         mesh2 = structured_quad_mesh(4, 4, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
         mesh3 = structured_quad_mesh(8, 8, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
-        
+
         ! Solve Poisson problem on each mesh
         call solve_poisson_quad(mesh1, uh1, errors(1))
         call solve_poisson_quad(mesh2, uh2, errors(2))
         call solve_poisson_quad(mesh3, uh3, errors(3))
-        
+
         h_values = [0.5_dp, 0.25_dp, 0.125_dp]
-        
+
         call check_condition(errors(2) < errors(1), &
             "Q1 convergence: error decreases with refinement 1")
         call check_condition(errors(3) < errors(2), &
             "Q1 convergence: error decreases with refinement 2")
-        
+
         ! Estimate convergence rate
         if (errors(1) > 1.0e-12_dp .and. errors(2) > 1.0e-12_dp) then
             convergence_rate = log(errors(2) / errors(1)) / log(h_values(2) / h_values(1))
             call check_condition(convergence_rate > 1.5_dp, &
                 "Q1 convergence: reasonable convergence rate")
         end if
-        
+
         call check_condition(all(errors > 0.0_dp), &
             "Q1 convergence: positive errors")
-        
+
         write(*,*) "   Q1 convergence rates: all tests passed"
         write(*,*) "   Errors:", errors
         if (errors(1) > 1.0e-12_dp) then
@@ -395,28 +395,28 @@ contains
         real(dp) :: assembly_time_tri, assembly_time_quad
         real(dp) :: solve_time_tri, solve_time_quad
         real(dp) :: performance_ratio
-        
+
         ! Create comparable meshes
         tri_mesh = unit_square_mesh(10)
         quad_mesh = structured_quad_mesh(7, 7, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
-        
+
         Vh_tri = function_space(tri_mesh, "Lagrange", 1)
         Vh_quad = function_space(quad_mesh, "Lagrange", 1)
-        
+
         ! Benchmark assembly times
         assembly_time_tri = benchmark_assembly(Vh_tri)
         assembly_time_quad = benchmark_assembly(Vh_quad)
-        
+
         call check_condition(assembly_time_tri > 0.0_dp, &
             "Q1 performance: triangular assembly time measured")
         call check_condition(assembly_time_quad > 0.0_dp, &
             "Q1 performance: quad assembly time measured")
-        
+
         ! Performance should be reasonable (within factor of 3)
         performance_ratio = assembly_time_quad / assembly_time_tri
         call check_condition(performance_ratio < 3.0_dp, &
             "Q1 performance: quad assembly within 3x triangular")
-        
+
         write(*,*) "   Q1 performance comparison: all tests passed"
         write(*,*) "   Assembly time ratio (quad/tri):", performance_ratio
     end subroutine test_q1_performance
@@ -429,23 +429,23 @@ contains
         integer :: i
         real(dp) :: x, y
         real(dp), parameter :: pi = acos(-1.0_dp)
-        
+
         quad_mesh = structured_quad_mesh(8, 8, 0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp)
         Vh = function_space(quad_mesh, "Lagrange", 1)
         uh = function(Vh)
-        
+
         do i = 1, Vh%ndof
             x = quad_mesh%data%vertices(1, i)
             y = quad_mesh%data%vertices(2, i)
             uh%values(i) = sin(pi * x) * sin(pi * y)
         end do
-        
+
         call check_condition(allocated(uh%values), &
             "Q1 solution plot: values allocated")
-        
+
         call plot(uh, filename="build/quad_solution.png", &
-                  title="Q1 quadrilateral solution")
-        
+            title="Q1 quadrilateral solution")
+
         write(*,*) "   Q1 quad solution plot: generated build/quad_solution.png"
     end subroutine test_q1_solution_plot
 
@@ -454,32 +454,32 @@ contains
         real(dp), intent(in) :: coords(2,4)
         integer, intent(in) :: nq
         real(dp) :: integral
-        
+
         ! Simple 2x2 Gauss quadrature for quadrilaterals
         real(dp), parameter :: gauss_2d(2) = [-0.5773502691896257_dp, 0.5773502691896257_dp]
         real(dp), parameter :: weights_2d(2) = [1.0_dp, 1.0_dp]
         real(dp) :: xi, eta, x_phys, y_phys, jac(2,2), det_jac, inv_jac(2,2)
         logical :: success
         integer :: i, j
-        
+
         integral = 0.0_dp
-        
+
         ! 2x2 Gauss quadrature (4 points)
         do i = 1, 2
             do j = 1, 2
                 xi = gauss_2d(i)
                 eta = gauss_2d(j)
-                
+
                 ! Map from reference to physical coordinates
                 call q1_reference_to_physical(xi, eta, coords, x_phys, y_phys)
-                
+
                 ! Compute Jacobian and determinant
                 call q1_jacobian(xi, eta, coords, jac, det_jac, inv_jac, success)
-                
+
                 if (success) then
                     ! Add weighted contribution
                     integral = integral + weights_2d(i) * weights_2d(j) * &
-                              func(x_phys, y_phys) * det_jac
+                        func(x_phys, y_phys) * det_jac
                 end if
             end do
         end do
@@ -506,7 +506,7 @@ contains
     function mixed_tri_quad_mesh() result(mesh)
         type(mesh_t) :: mesh
         integer :: i
-        
+
         ! Simple mixed mesh: one cell split into triangles and one quadrilateral
         mesh%data%n_vertices = 6
         mesh%data%n_triangles = 2
@@ -514,11 +514,11 @@ contains
         mesh%data%has_triangles = .true.
         mesh%data%has_quads = .true.
         mesh%data%has_mixed_elements = .true.
-        
+
         allocate(mesh%data%vertices(2, mesh%data%n_vertices))
         allocate(mesh%data%triangles(3, mesh%data%n_triangles))
         allocate(mesh%data%quads(4, mesh%data%n_quads))
-        
+
         ! Vertex coordinates for strip [0,2] x [0,1]
         mesh%data%vertices(:, 1) = [0.0_dp, 0.0_dp]
         mesh%data%vertices(:, 2) = [1.0_dp, 0.0_dp]
@@ -526,14 +526,14 @@ contains
         mesh%data%vertices(:, 4) = [0.0_dp, 1.0_dp]
         mesh%data%vertices(:, 5) = [1.0_dp, 1.0_dp]
         mesh%data%vertices(:, 6) = [2.0_dp, 1.0_dp]
-        
+
         ! Two triangles in the left cell
         mesh%data%triangles(:, 1) = [1, 2, 5]
         mesh%data%triangles(:, 2) = [1, 5, 4]
-        
+
         ! One quadrilateral in the right cell (counter-clockwise)
         mesh%data%quads(:, 1) = [2, 3, 6, 5]
-        
+
         call mesh%data%build_connectivity()
         call mesh%data%find_boundary()
     end function mixed_tri_quad_mesh
@@ -545,12 +545,12 @@ contains
         real(dp) :: edge_lengths(4)
         real(dp) :: x1, y1, x2, y2
         real(dp) :: quad_quality
-        
+
         if (mesh%data%n_quads <= 0) then
             quality = 0.0_dp
             return
         end if
-        
+
         quality = 1.0_dp
         do q = 1, mesh%data%n_quads
             do k = 1, 4
@@ -571,14 +571,14 @@ contains
         type(mesh_t), intent(in) :: mesh
         type(function_t), intent(out) :: uh
         real(dp), intent(out) :: error
-        
+
         type(function_space_t) :: Vh
         real(dp) :: total_error2
         real(dp) :: x_phys, y_phys
         real(dp) :: u_exact, u_h
         real(dp), parameter :: pi = acos(-1.0_dp)
         real(dp), parameter :: gauss(2) = [-0.5773502691896257_dp, &
-                                           0.5773502691896257_dp]
+            0.5773502691896257_dp]
         real(dp), parameter :: w(2) = [1.0_dp, 1.0_dp]
         real(dp) :: xi, eta, jac(2,2), det_jac, inv_jac(2,2)
         real(dp) :: N(4), nodal_values(4)
@@ -586,20 +586,20 @@ contains
         logical :: success
         integer :: i, j, q, vi
         integer :: v_ids(4)
-        
+
         ! Function space and nodal values (interpolation of analytic solution)
         Vh = function_space(mesh, "Lagrange", 1)
         uh = function(Vh)
-        
+
         do i = 1, Vh%ndof
             x_phys = mesh%data%vertices(1, i)
             y_phys = mesh%data%vertices(2, i)
             uh%values(i) = sin(pi * x_phys) * sin(pi * y_phys)
         end do
-        
+
         ! L2 error of Q1 interpolation using 2x2 Gauss quadrature
         total_error2 = 0.0_dp
-        
+
         do q = 1, mesh%data%n_quads
             v_ids = mesh%data%quads(:, q)
             do i = 1, 4
@@ -608,26 +608,26 @@ contains
                 coords(2, i) = mesh%data%vertices(2, vi)
                 nodal_values(i) = uh%values(vi)
             end do
-            
+
             do i = 1, 2
                 do j = 1, 2
                     xi = gauss(i)
                     eta = gauss(j)
-                    
+
                     call q1_shape_functions(xi, eta, N)
                     call q1_reference_to_physical(xi, eta, coords, x_phys, y_phys)
                     call q1_jacobian(xi, eta, coords, jac, det_jac, inv_jac, success)
-                    
+
                     if (success) then
                         u_h = sum(N * nodal_values)
                         u_exact = sin(pi * x_phys) * sin(pi * y_phys)
                         total_error2 = total_error2 + (u_h - u_exact)**2 * det_jac * &
-                                       w(i) * w(j)
+                            w(i) * w(j)
                     end if
                 end do
             end do
         end do
-        
+
         if (total_error2 > 0.0_dp) then
             error = sqrt(total_error2)
         else
@@ -639,14 +639,14 @@ contains
         type(function_space_t), intent(in) :: Vh
         real(dp) :: time
         integer :: n_elements
-        
+
         if (.not. associated(Vh%mesh)) then
             time = 0.0_dp
             return
         end if
-        
+
         n_elements = Vh%mesh%data%n_triangles + Vh%mesh%data%n_quads
-        
+
         if (n_elements <= 0 .or. Vh%ndof <= 0) then
             time = 0.0_dp
         else

--- a/test/test_robust_predicates.f90
+++ b/test/test_robust_predicates.f90
@@ -42,17 +42,17 @@ contains
 
         ! CCW triangle: (0,0) -> (1,0) -> (1,1)
         orient = orient2d_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp,             &
-                                 1.0_dp, 1.0_dp)
+            1.0_dp, 1.0_dp)
         call check_condition(orient == ORIENT_CCW, "CCW triangle detected")
 
         ! CW triangle: (0,0) -> (1,1) -> (1,0)
         orient = orient2d_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, 1.0_dp,             &
-                                 1.0_dp, 0.0_dp)
+            1.0_dp, 0.0_dp)
         call check_condition(orient == ORIENT_CW, "CW triangle detected")
 
         ! CCW triangle: (0,0) -> (1,0) -> (0,1)
         orient = orient2d_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp,             &
-                                 0.0_dp, 1.0_dp)
+            0.0_dp, 1.0_dp)
         call check_condition(orient == ORIENT_CCW, "CCW right triangle detected")
     end subroutine test_orientation_basic
 
@@ -70,7 +70,7 @@ contains
         call init_robust_coords(rc, points, 3)
 
         orient = orient2d_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp,             &
-                                 2.0_dp, 0.0_dp)
+            2.0_dp, 0.0_dp)
         call check_condition(orient == ORIENT_COLLINEAR,                         &
             "Collinear points on x-axis")
 
@@ -82,7 +82,7 @@ contains
         call init_robust_coords(rc, points, 3)
 
         orient = orient2d_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, 1.0_dp,             &
-                                 2.0_dp, 2.0_dp)
+            2.0_dp, 2.0_dp)
         call check_condition(orient == ORIENT_COLLINEAR,                         &
             "Collinear points on diagonal")
     end subroutine test_orientation_collinear
@@ -97,19 +97,19 @@ contains
         points(:, 1) = [0.0_dp, 0.0_dp]
         points(:, 2) = [1.0_dp, 0.0_dp]
         points(:, 3) = [0.0_dp, 1.0_dp]
-        points(:, 4) = [0.25_dp, 0.25_dp]  ! Inside
+        points(:, 4) = [0.25_dp, 0.25_dp] ! Inside
 
         call init_robust_coords(rc, points, 4)
 
         ! Point (0.25, 0.25) should be inside circumcircle of (0,0)-(1,0)-(0,1)
         ! Circumcircle center is at (0.5, 0.5), radius = sqrt(0.5)
         inside = incircle_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp,             &
-                                 0.0_dp, 1.0_dp, 0.25_dp, 0.25_dp)
+            0.0_dp, 1.0_dp, 0.25_dp, 0.25_dp)
         call check_condition(inside, "Point inside circumcircle")
 
         ! Point (2.0, 2.0) should be outside
         inside = incircle_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp,             &
-                                 0.0_dp, 1.0_dp, 2.0_dp, 2.0_dp)
+            0.0_dp, 1.0_dp, 2.0_dp, 2.0_dp)
         call check_condition(.not. inside, "Point outside circumcircle")
     end subroutine test_incircle_basic
 
@@ -122,14 +122,14 @@ contains
         ! Equilateral-ish triangle
         points(:, 1) = [0.0_dp, 0.0_dp]
         points(:, 2) = [2.0_dp, 0.0_dp]
-        points(:, 3) = [1.0_dp, 1.732050808_dp]  ! sqrt(3)
+        points(:, 3) = [1.0_dp, 1.732050808_dp] ! sqrt(3)
         points(:, 4) = [1.0_dp, 0.0_dp]
 
         call init_robust_coords(rc, points, 4)
 
         ! Point on the edge exercises boundary behavior of incircle_robust.
         inside = incircle_robust(rc, 0.0_dp, 0.0_dp, 2.0_dp, 0.0_dp,             &
-                                 1.0_dp, 1.732050808_dp, 1.0_dp, 0.0_dp)
+            1.0_dp, 1.732050808_dp, 1.0_dp, 0.0_dp)
         ! We only check that the call succeeds; exact classification may
         ! depend on integer rounding in robust coordinates.
         call check_condition(.true., "Incircle edge case handled")
@@ -156,7 +156,7 @@ contains
 
         ! Should detect as collinear (within integer precision)
         orient = orient2d_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, tiny_offset,        &
-                                 2.0_dp, 2.0_dp * tiny_offset)
+            2.0_dp, 2.0_dp * tiny_offset)
         ! Due to integer rounding, very nearly collinear points become collinear
         call check_condition(orient == ORIENT_COLLINEAR,                         &
             "Nearly collinear points handled robustly")
@@ -164,12 +164,12 @@ contains
         ! Slightly off collinear - should detect correctly
         points(:, 1) = [0.0_dp, 0.0_dp]
         points(:, 2) = [1.0_dp, 0.0_dp]
-        points(:, 3) = [2.0_dp, 0.001_dp]  ! Clearly above the line
+        points(:, 3) = [2.0_dp, 0.001_dp] ! Clearly above the line
 
         call init_robust_coords(rc, points, 3)
 
         orient = orient2d_robust(rc, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp,             &
-                                 2.0_dp, 0.001_dp)
+            2.0_dp, 0.001_dp)
         call check_condition(orient == ORIENT_CCW,                               &
             "Slightly non-collinear detected as CCW")
     end subroutine test_near_degenerate
@@ -188,8 +188,8 @@ contains
         call init_robust_coords(rc, points, 3)
 
         orient = orient2d_robust(rc, 1000000.0_dp, 1000000.0_dp,                  &
-                                 1000001.0_dp, 1000000.0_dp,                      &
-                                 1000001.0_dp, 1000001.0_dp)
+            1000001.0_dp, 1000000.0_dp,                      &
+            1000001.0_dp, 1000001.0_dp)
         call check_condition(orient == ORIENT_CCW,                               &
             "Large coordinates: CCW detected")
 
@@ -201,8 +201,8 @@ contains
         call init_robust_coords(rc, points, 3)
 
         orient = orient2d_robust(rc, 1.0e8_dp, 1.0e8_dp,                          &
-                                 1.0e8_dp + 0.001_dp, 1.0e8_dp,                   &
-                                 1.0e8_dp, 1.0e8_dp + 0.001_dp)
+            1.0e8_dp + 0.001_dp, 1.0e8_dp,                   &
+            1.0e8_dp, 1.0e8_dp + 0.001_dp)
         call check_condition(orient == ORIENT_CCW,                               &
             "Small triangle in large coords: CCW detected")
     end subroutine test_large_coordinates

--- a/test/test_simple_diagnostic.f90
+++ b/test/test_simple_diagnostic.f90
@@ -9,21 +9,21 @@ program test_simple_diagnostic
     real(dp) :: points(2, 3)
     integer, allocatable :: constraint_segments(:,:)
     integer :: i
-    
+
     write(*,*) "=== Simple Triangulation Diagnostic ==="
-    
+
     ! Create simple triangle: (0,0), (1,0), (0.5,1)
     points(:, 1) = [0.0_dp, 0.0_dp]
     points(:, 2) = [1.0_dp, 0.0_dp]
     points(:, 3) = [0.5_dp, 1.0_dp]
-    
+
     allocate(constraint_segments(2, 0))
     call constrained_delaunay_triangulate(points, constraint_segments, mesh)
-    
+
     write(*,*) "Input points: 3"
     write(*,*) "Output vertices:", mesh%npoints
     write(*,*) "Output triangles:", mesh%ntriangles
-    
+
     write(*,*) "Triangles:"
     do i = 1, mesh%ntriangles
         if (mesh%triangles(i)%valid) then
@@ -32,7 +32,7 @@ program test_simple_diagnostic
             write(*,'(A,I0,A)') "  Triangle ", i, ": [invalid]"
         end if
     end do
-    
+
     write(*,*) "Vertices:"
     do i = 1, mesh%npoints
         write(*,'(A,I0,A,2F8.3)') "  Vertex ", i, ": ", mesh%points(i)%x, mesh%points(i)%y

--- a/test/test_solver_integration.f90
+++ b/test/test_solver_integration.f90
@@ -5,9 +5,9 @@ program test_solver_integration
     implicit none
 
     write(*,*) "Testing solver integration and validation..."
-    
+
     call test_direct_solver_accuracy()
-    call test_gmres_solver_convergence() 
+    call test_gmres_solver_convergence()
     call test_solver_consistency()
     call test_manufactured_solutions()
     call test_convergence_rates()
@@ -15,7 +15,7 @@ program test_solver_integration
     call test_boundary_condition_integration()
     call test_solver_scaling()
     call test_high_level_advanced_solvers()
-    
+
     call check_summary("Solver Integration")
 
 contains
@@ -32,23 +32,23 @@ contains
         real(dp) :: max_val, center_val, expected_max
         integer :: i, center_node
         real(dp) :: x, y, min_dist, dist
-        
+
         ! Test Poisson problem with known solution properties
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Find center node
         min_dist = huge(1.0_dp)
         center_node = 1
@@ -61,11 +61,11 @@ contains
                 center_node = i
             end if
         end do
-        
+
         max_val = maxval(uh%values)
         center_val = uh%values(center_node)
-        expected_max = 0.125_dp  ! Theoretical maximum for -Δu = 1
-        
+        expected_max = 0.125_dp ! Theoretical maximum for -Δu = 1
+
         call check_condition(max_val > 0.01_dp, &
             "Direct solver: positive solution values")
         call check_condition(max_val < 0.15_dp, &
@@ -74,7 +74,7 @@ contains
             "Direct solver: maximum near center")
         call check_condition(abs(max_val - expected_max) / expected_max < 0.5_dp, &
             "Direct solver: reasonable accuracy")
-        
+
         write(*,*) "   Maximum value:", max_val
         write(*,*) "   Center value:", center_val
         write(*,*) "   Expected maximum:", expected_max
@@ -91,44 +91,44 @@ contains
         type(vector_bc_t) :: bc
         type(form_expr_t) :: a, L
         real(dp) :: solution_norm, max_component
-        
+
         ! Test curl-curl problem with GMRES
-        mesh = unit_square_mesh(4)  ! Small mesh for GMRES test
+        mesh = unit_square_mesh(4) ! Small mesh for GMRES test
         Vh = vector_function_space(mesh, "Nedelec", 1)
-        
+
         E = vector_trial_function(Vh)
         F = vector_test_function(Vh)
         j = vector_function(Vh)
-        
+
         ! Set up simple current source
         if (allocated(j%values)) then
-            j%values = 0.1_dp  ! Simple constant current
+            j%values = 0.1_dp ! Simple constant current
         end if
-        
+
         a = inner(curl(E), curl(F))*dx + inner(E, F)*dx
         L = inner(j, F)*dx
-        
+
         bc = vector_bc(Vh, [0.0_dp, 0.0_dp])
         Eh = vector_function(Vh)
-        
+
         call solve(a == L, Eh, bc, "gmres")
-        
+
         ! Check GMRES solution properties
         solution_norm = 0.0_dp
         max_component = 0.0_dp
-        
+
         if (allocated(Eh%values)) then
             solution_norm = sqrt(sum(Eh%values**2))
             max_component = maxval(abs(Eh%values))
         end if
-        
+
         call check_condition(solution_norm >= 0.0_dp, &
             "GMRES solver: non-negative solution norm")
         call check_condition(solution_norm < 10.0_dp, &
             "GMRES solver: bounded solution")
         call check_condition(max_component < 5.0_dp, &
             "GMRES solver: reasonable component values")
-        
+
         write(*,*) "   GMRES solution norm:", solution_norm
         write(*,*) "   Max component:", max_component
         write(*,*) "   Vector DOFs:", Vh%ndof
@@ -145,42 +145,42 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: diff_norm, max_diff
         integer :: i
-        
+
         ! Test that same problem gives same solution
         mesh = unit_square_mesh(4)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         ! Solve same problem twice with same BC
         bc1 = dirichlet_bc(Vh, 0.0_dp)
         uh1 = function(Vh)
         call solve(a == L, uh1, bc1)
-        
+
         bc2 = dirichlet_bc(Vh, 0.0_dp)
         uh2 = function(Vh)
         call solve(a == L, uh2, bc2)
-        
+
         ! Check solutions are identical
         max_diff = 0.0_dp
         diff_norm = 0.0_dp
-        
+
         do i = 1, Vh%ndof
             max_diff = max(max_diff, abs(uh1%values(i) - uh2%values(i)))
             diff_norm = diff_norm + (uh1%values(i) - uh2%values(i))**2
         end do
         diff_norm = sqrt(diff_norm)
-        
+
         call check_condition(max_diff < 1.0e-12_dp, &
             "Solver consistency: identical problems give identical solutions")
         call check_condition(diff_norm < 1.0e-10_dp, &
             "Solver consistency: L2 difference is zero")
-        
+
         write(*,*) "   Max difference:", max_diff
         write(*,*) "   L2 difference:", diff_norm
     end subroutine test_solver_consistency
@@ -196,53 +196,53 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: max_error, l2_error, u_exact, x, y, dist_to_boundary
         integer :: i
-        
+
         ! Test quadratic manufactured solution u(x,y) = x(1-x)y(1-y)
         ! Then -Δu = 2y(1-y) + 2x(1-x), but solver uses f=1
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
-        f = constant(1.0_dp)  ! Note: solver hardcodes f=1
-        
+        f = constant(1.0_dp) ! Note: solver hardcodes f=1
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Compare with expected solution shape
         max_error = 0.0_dp
         l2_error = 0.0_dp
-        
+
         ! Simple check: solution should be smooth and bowl-shaped
         ! Avoid complex manufactured solution comparison that can cause NaN
-        
+
         ! Check that solution varies smoothly from boundary to interior
         do i = 1, Vh%ndof
             x = Vh%mesh%data%vertices(1, i)
             y = Vh%mesh%data%vertices(2, i)
-            
+
             ! Distance from boundary (minimum distance to any edge)
             dist_to_boundary = min(x, 1.0_dp - x, y, 1.0_dp - y)
-            
+
             ! Interior points should have higher values
             if (dist_to_boundary > 0.1_dp .and. uh%values(i) < 0.001_dp) then
-                max_error = max_error + 1.0_dp  ! Flag as error
+                max_error = max_error + 1.0_dp ! Flag as error
             end if
         end do
-        
-        l2_error = maxval(uh%values) - minval(uh%values)  ! Solution range
-        
+
+        l2_error = maxval(uh%values) - minval(uh%values) ! Solution range
+
         ! Test qualitative properties rather than exact match
         call check_condition(maxval(uh%values) > 0.01_dp, &
             "Manufactured solution: positive interior values")
         call check_condition(l2_error > 0.001_dp, &
             "Manufactured solution: reasonable solution range")
-        
+
         write(*,*) "   Max error:", max_error
         write(*,*) "   L2 error:", l2_error
         write(*,*) "   Relative L2 error:", l2_error / maxval(uh%values)
@@ -260,49 +260,49 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: max_vals(3), h_vals(3), rates(2)
         integer :: n_vals(3), i
-        
+
         ! Test convergence on sequence of meshes
         n_vals = [4, 6, 8]
         h_vals = 1.0_dp / real(n_vals, dp)
-        
+
         do i = 1, 3
             mesh = unit_square_mesh(n_vals(i))
             Vh = function_space(mesh, "Lagrange", 1)
-            
+
             u = trial_function(Vh)
             v = test_function(Vh)
             f = constant(1.0_dp)
-            
+
             a = inner(grad(u), grad(v))*dx
             L = f*v*dx
-            
+
             bc = dirichlet_bc(Vh, 0.0_dp)
             uh = function(Vh)
-            
+
             call solve(a == L, uh, bc)
             max_vals(i) = maxval(uh%values)
         end do
-        
+
         ! Compute convergence rates with bounds checking
         if (abs(max_vals(1)) > 1.0e-12_dp .and. abs(max_vals(2) - max_vals(1)) > 1.0e-12_dp) then
             rates(1) = log(abs(max_vals(2) - max_vals(1)) / abs(max_vals(1))) / log(h_vals(2) / h_vals(1))
         else
             rates(1) = 0.0_dp
         end if
-        
+
         if (abs(max_vals(2)) > 1.0e-12_dp .and. abs(max_vals(3) - max_vals(2)) > 1.0e-12_dp) then
             rates(2) = log(abs(max_vals(3) - max_vals(2)) / abs(max_vals(2))) / log(h_vals(3) / h_vals(2))
         else
             rates(2) = 0.0_dp
         end if
-        
+
         call check_condition(max_vals(2) > max_vals(1), &
             "Convergence rates: refinement improves accuracy 1")
         call check_condition(max_vals(3) > max_vals(2), &
             "Convergence rates: refinement improves accuracy 2")
         call check_condition(maxval(abs(rates)) < 20.0_dp, &
             "Convergence rates: reasonable rate values")
-        
+
         write(*,*) "   Mesh sizes:", n_vals
         write(*,*) "   Max values:", max_vals
         write(*,*) "   h values:", h_vals
@@ -321,44 +321,44 @@ contains
         logical :: small_solved, medium_solved, large_solved
         integer :: sizes(3), i
         real(dp) :: max_vals(3)
-        
+
         sizes = [3, 6, 10]
         small_solved = .false.
         medium_solved = .false.
         large_solved = .false.
-        
+
         ! Test solver on different problem sizes
         do i = 1, 3
             mesh = unit_square_mesh(sizes(i))
             Vh = function_space(mesh, "Lagrange", 1)
-            
+
             u = trial_function(Vh)
             v = test_function(Vh)
             f = constant(1.0_dp)
-            
+
             a = inner(grad(u), grad(v))*dx
             L = f*v*dx
-            
+
             bc = dirichlet_bc(Vh, 0.0_dp)
             uh = function(Vh)
-            
+
             call solve(a == L, uh, bc)
             max_vals(i) = maxval(uh%values)
-            
+
             if (max_vals(i) > 1.0e-6_dp .and. max_vals(i) < 1.0_dp) then
                 if (i == 1) small_solved = .true.
                 if (i == 2) medium_solved = .true.
                 if (i == 3) large_solved = .true.
             end if
         end do
-        
+
         call check_condition(small_solved, &
             "Solver robustness: small problem solved")
         call check_condition(medium_solved, &
             "Solver robustness: medium problem solved")
         call check_condition(large_solved, &
             "Solver robustness: large problem solved")
-        
+
         write(*,*) "   Problem sizes (DOFs):"
         do i = 1, 3
             mesh = unit_square_mesh(sizes(i))
@@ -378,27 +378,27 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: bc_vals(3), max_vals(3), expected_offset
         integer :: i, j, boundary_count
-        
+
         bc_vals = [0.0_dp, 0.5_dp, 1.0_dp]
-        
+
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         ! Test solver with different boundary values
         do i = 1, 3
             u = trial_function(Vh)
             v = test_function(Vh)
             f = constant(1.0_dp)
-            
+
             a = inner(grad(u), grad(v))*dx
             L = f*v*dx
-            
+
             bc = dirichlet_bc(Vh, bc_vals(i))
             uh = function(Vh)
-            
+
             call solve(a == L, uh, bc)
             max_vals(i) = maxval(uh%values)
-            
+
             ! Check boundary values are correctly applied
             boundary_count = 0
             do j = 1, Vh%ndof
@@ -411,14 +411,14 @@ contains
                 end if
             end do
         end do
-        
+
         call check_condition(boundary_count > 0, &
             "BC integration: found boundary vertices")
         call check_condition(max_vals(2) > max_vals(1), &
             "BC integration: higher BC gives higher maximum 1")
         call check_condition(max_vals(3) > max_vals(2), &
             "BC integration: higher BC gives higher maximum 2")
-        
+
         write(*,*) "   BC values:", bc_vals
         write(*,*) "   Max solution values:", max_vals
         write(*,*) "   Boundary vertices:", boundary_count
@@ -435,38 +435,38 @@ contains
         type(form_expr_t) :: a, L
         integer :: dofs(3), i
         real(dp) :: solutions(3), ratios(2)
-        
+
         ! Test scaling of solution accuracy with DOF count
         do i = 1, 3
-            mesh = unit_square_mesh(3 + i)  ! 4, 5, 6
+            mesh = unit_square_mesh(3 + i) ! 4, 5, 6
             Vh = function_space(mesh, "Lagrange", 1)
             dofs(i) = Vh%ndof
-            
+
             u = trial_function(Vh)
             v = test_function(Vh)
             f = constant(1.0_dp)
-            
+
             a = inner(grad(u), grad(v))*dx
             L = f*v*dx
-            
+
             bc = dirichlet_bc(Vh, 0.0_dp)
             uh = function(Vh)
-            
+
             call solve(a == L, uh, bc)
             solutions(i) = maxval(uh%values)
         end do
-        
+
         ! Compute improvement ratios
         ratios(1) = solutions(2) / solutions(1)
         ratios(2) = solutions(3) / solutions(2)
-        
+
         call check_condition(solutions(2) >= solutions(1) * 0.9_dp, &
             "Solver scaling: more DOFs give better accuracy 1")
         call check_condition(solutions(3) >= solutions(1) * 0.9_dp, &
             "Solver scaling: more DOFs maintain accuracy 2")
         call check_condition(all(ratios > 0.5_dp) .and. all(ratios < 3.0_dp), &
             "Solver scaling: reasonable improvement ratios")
-        
+
         write(*,*) "   DOF counts:", dofs
         write(*,*) "   Solution maxima:", solutions
         write(*,*) "   Improvement ratios:", ratios
@@ -507,25 +507,25 @@ contains
 
         ! Direct LAPACK solve through high-level API
         opts_direct = solver_options(method="lapack_lu", &
-                                     tolerance=1.0e-12_dp, &
-                                     max_iterations=ndof)
+            tolerance=1.0e-12_dp, &
+            max_iterations=ndof)
         call solve(a == L, uh_direct, bc, opts_direct, stats_direct)
 
         ! Iterative PCG+ILU solve through high-level API
         opts_pcg = solver_options(method="pcg", preconditioner="ilu", &
-                                  tolerance=1.0e-6_dp, &
-                                  tolerance_type="absolute", &
-                                  max_iterations=5*ndof)
+            tolerance=1.0e-6_dp, &
+            tolerance_type="absolute", &
+            max_iterations=5*ndof)
         call solve(a == L, uh_pcg, bc, opts_pcg, stats_pcg)
 
         res_direct = sqrt(sum((matmul(K_mat, uh_direct%values) - rhs)**2))/ &
-                     real(ndof, dp)
+            real(ndof, dp)
         res_pcg = sqrt(sum((matmul(K_mat, uh_pcg%values) - rhs)**2))/ &
-                  real(ndof, dp)
+            real(ndof, dp)
 
         norm_direct = sqrt(sum(uh_direct%values**2))
         diff_norm = sqrt(sum((uh_direct%values - uh_pcg%values)**2))/ &
-                    max(norm_direct, 1.0e-12_dp)
+            max(norm_direct, 1.0e-12_dp)
 
         call check_condition(stats_direct%converged, &
             "High-level solvers: direct converged")
@@ -536,7 +536,7 @@ contains
         call check_condition(diff_norm < 1.0e-3_dp, &
             "High-level solvers: PCG solution matches direct")
         call check_condition(stats_pcg%iterations > 1 .and. &
-                             stats_pcg%iterations < 5*ndof, &
+            stats_pcg%iterations < 5*ndof, &
             "High-level solvers: PCG iteration count reasonable")
 
         write(*,*) "   High-level direct residual:", res_direct

--- a/test/test_solver_validation.f90
+++ b/test/test_solver_validation.f90
@@ -5,7 +5,7 @@ program test_solver_validation
     implicit none
 
     write(*,*) "Testing advanced solver validation..."
-    
+
     call test_analytical_solutions()
     call test_error_norms_convergence()
     call test_solver_conditioning()
@@ -13,7 +13,7 @@ program test_solver_validation
     call test_matrix_properties()
     call test_solution_smoothness()
     call test_energy_conservation()
-    
+
     call check_summary("Advanced Solver Validation")
 
 contains
@@ -30,24 +30,24 @@ contains
         real(dp) :: center_val, expected_center, relative_error
         integer :: i, center_node
         real(dp) :: x, y, min_dist, dist
-        
+
         ! Test against known analytical solution for unit square
         ! For -Δu = 1 with u=0 on boundary, analytical solution involves Fourier series
         mesh = unit_square_mesh(8)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Find center point
         min_dist = huge(1.0_dp)
         center_node = 1
@@ -60,18 +60,18 @@ contains
                 center_node = i
             end if
         end do
-        
+
         center_val = uh%values(center_node)
-        expected_center = 0.073_dp  ! Approximate from analytical solution
+        expected_center = 0.073_dp ! Approximate from analytical solution
         relative_error = abs(center_val - expected_center) / expected_center
-        
+
         call check_condition(center_val > 0.01_dp, &
             "Analytical solutions: positive center value")
         call check_condition(center_val < 0.15_dp, &
             "Analytical solutions: bounded center value")
         call check_condition(relative_error < 1.0_dp, &
             "Analytical solutions: reasonable accuracy")
-        
+
         write(*,*) "   Center value:", center_val
         write(*,*) "   Expected center:", expected_center
         write(*,*) "   Relative error:", relative_error
@@ -89,30 +89,30 @@ contains
         real(dp) :: l2_norms(3), h1_norms(3), h_vals(3)
         real(dp) :: l2_rate, h1_rate
         integer :: n_vals(3), i, j
-        
+
         n_vals = [4, 6, 8]
         h_vals = 1.0_dp / real(n_vals, dp)
-        
+
         ! Compute error norms on sequence of meshes
         do i = 1, 3
             mesh = unit_square_mesh(n_vals(i))
             Vh = function_space(mesh, "Lagrange", 1)
-            
+
             u = trial_function(Vh)
             v = test_function(Vh)
             f = constant(1.0_dp)
-            
+
             a = inner(grad(u), grad(v))*dx
             L = f*v*dx
-            
+
             bc = dirichlet_bc(Vh, 0.0_dp)
             uh = function(Vh)
-            
+
             call solve(a == L, uh, bc)
-            
+
             ! Compute approximate L2 norm
             l2_norms(i) = sqrt(sum(uh%values**2) / real(Vh%ndof, dp))
-            
+
             ! Compute approximate H1 norm (simplified)
             h1_norms(i) = 0.0_dp
             do j = 1, Vh%ndof-1
@@ -120,20 +120,20 @@ contains
             end do
             h1_norms(i) = sqrt(h1_norms(i) + l2_norms(i)**2)
         end do
-        
+
         ! Compute convergence rates
         if (l2_norms(1) > 1.0e-12_dp .and. l2_norms(2) > 1.0e-12_dp) then
             l2_rate = log(l2_norms(2) / l2_norms(1)) / log(h_vals(2) / h_vals(1))
         else
             l2_rate = 0.0_dp
         end if
-        
+
         if (h1_norms(1) > 1.0e-12_dp .and. h1_norms(2) > 1.0e-12_dp) then
             h1_rate = log(h1_norms(2) / h1_norms(1)) / log(h_vals(2) / h_vals(1))
         else
             h1_rate = 0.0_dp
         end if
-        
+
         call check_condition(l2_norms(2) > l2_norms(1), &
             "Error convergence: L2 norm increases with refinement")
         call check_condition(h1_norms(2) > h1_norms(1), &
@@ -142,7 +142,7 @@ contains
             "Error convergence: reasonable L2 rate")
         call check_condition(abs(h1_rate) < 5.0_dp, &
             "Error convergence: reasonable H1 rate")
-        
+
         write(*,*) "   L2 norms:", l2_norms
         write(*,*) "   H1 norms:", h1_norms
         write(*,*) "   L2 convergence rate:", l2_rate
@@ -160,40 +160,40 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: solution_norm, perturbation, perturbed_norm
         real(dp) :: condition_estimate
-        
+
         ! Test solver stability with slightly different problems
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
         solution_norm = sqrt(sum(uh%values**2))
-        
+
         ! Solve with slightly perturbed BC
         bc = dirichlet_bc(Vh, 1.0e-6_dp)
         call solve(a == L, uh, bc)
         perturbed_norm = sqrt(sum(uh%values**2))
-        
+
         ! Estimate condition number effect
         perturbation = 1.0e-6_dp
         condition_estimate = abs(perturbed_norm - solution_norm) / perturbation
-        
+
         call check_condition(solution_norm > 0.0_dp, &
             "Solver conditioning: non-zero solution norm")
         call check_condition(condition_estimate < 1.0e6_dp, &
             "Solver conditioning: reasonable conditioning")
         call check_condition(abs(perturbed_norm - solution_norm) > 1.0e-12_dp, &
             "Solver conditioning: perturbation has effect")
-        
+
         write(*,*) "   Original solution norm:", solution_norm
         write(*,*) "   Perturbed solution norm:", perturbed_norm
         write(*,*) "   Condition estimate:", condition_estimate
@@ -209,32 +209,32 @@ contains
         type(vector_bc_t) :: bc1, bc2
         type(form_expr_t) :: a, L
         real(dp) :: norm1, norm2, diff_norm
-        
+
         ! Test GMRES with different initial conditions
         mesh = unit_square_mesh(4)
         Vh = vector_function_space(mesh, "Nedelec", 1)
-        
+
         E = vector_trial_function(Vh)
         F = vector_test_function(Vh)
         j = vector_function(Vh)
-        
+
         ! Set up current source
         if (allocated(j%values)) then
             j%values = 0.1_dp
         end if
-        
+
         a = inner(curl(E), curl(F))*dx + inner(E, F)*dx
         L = inner(j, F)*dx
-        
+
         ! Solve with different boundary conditions
         bc1 = vector_bc(Vh, [0.0_dp, 0.0_dp])
         Eh1 = vector_function(Vh)
         call solve(a == L, Eh1, bc1, "gmres")
-        
+
         bc2 = vector_bc(Vh, [0.1_dp, 0.0_dp])
         Eh2 = vector_function(Vh)
         call solve(a == L, Eh2, bc2, "gmres")
-        
+
         ! Compute solution norms
         if (allocated(Eh1%values) .and. allocated(Eh2%values)) then
             norm1 = sqrt(sum(Eh1%values**2))
@@ -245,7 +245,7 @@ contains
             norm2 = 0.0_dp
             diff_norm = 0.0_dp
         end if
-        
+
         call check_condition(norm1 >= 0.0_dp, &
             "GMRES convergence: non-negative norm 1")
         call check_condition(norm2 >= 0.0_dp, &
@@ -254,7 +254,7 @@ contains
             "GMRES convergence: valid difference computation")
         call check_condition(diff_norm < 10.0_dp * max(norm1, norm2), &
             "GMRES convergence: solutions are reasonably close")
-        
+
         write(*,*) "   GMRES solution norm 1:", norm1
         write(*,*) "   GMRES solution norm 2:", norm2
         write(*,*) "   Difference norm:", diff_norm
@@ -270,30 +270,30 @@ contains
         type(dirichlet_bc_t) :: bc
         type(form_expr_t) :: a, L
         real(dp) :: energy1, energy2, energy_ratio
-        
+
         ! Test matrix positive definiteness through energy
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         ! Test with two different boundary values
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
         call solve(a == L, uh, bc)
         energy1 = sum(uh%values**2)
-        
+
         bc = dirichlet_bc(Vh, 0.1_dp)
         call solve(a == L, uh, bc)
         energy2 = sum(uh%values**2)
-        
+
         energy_ratio = energy2 / energy1
-        
+
         call check_condition(energy1 >= 0.0_dp, &
             "Matrix properties: non-negative energy 1")
         call check_condition(energy2 >= 0.0_dp, &
@@ -302,7 +302,7 @@ contains
             "Matrix properties: higher BC gives higher energy")
         call check_condition(energy_ratio > 1.0_dp .and. energy_ratio < 1000.0_dp, &
             "Matrix properties: reasonable energy scaling")
-        
+
         write(*,*) "   Energy with BC=0:", energy1
         write(*,*) "   Energy with BC=0.1:", energy2
         write(*,*) "   Energy ratio:", energy_ratio
@@ -319,37 +319,37 @@ contains
         type(form_expr_t) :: a, L
         real(dp) :: max_gradient, avg_gradient, gradient_variance, grad_approx
         integer :: i, gradient_count
-        
+
         ! Test solution smoothness
         mesh = unit_square_mesh(6)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Compute approximate gradients (simplified)
         max_gradient = 0.0_dp
         avg_gradient = 0.0_dp
         gradient_count = 0
-        
+
         do i = 1, Vh%ndof-1
             grad_approx = abs(uh%values(i+1) - uh%values(i))
             max_gradient = max(max_gradient, grad_approx)
             avg_gradient = avg_gradient + grad_approx
             gradient_count = gradient_count + 1
         end do
-        
+
         if (gradient_count > 0) avg_gradient = avg_gradient / real(gradient_count, dp)
-        
+
         ! Compute gradient variance
         gradient_variance = 0.0_dp
         do i = 1, Vh%ndof-1
@@ -357,14 +357,14 @@ contains
             gradient_variance = gradient_variance + (grad_approx - avg_gradient)**2
         end do
         if (gradient_count > 1) gradient_variance = gradient_variance / real(gradient_count-1, dp)
-        
+
         call check_condition(max_gradient < 1.0_dp, &
             "Solution smoothness: bounded gradients")
         call check_condition(avg_gradient > 0.0_dp, &
             "Solution smoothness: positive average gradient")
         call check_condition(gradient_variance < 1.0_dp, &
             "Solution smoothness: reasonable gradient variance")
-        
+
         write(*,*) "   Max gradient:", max_gradient
         write(*,*) "   Average gradient:", avg_gradient
         write(*,*) "   Gradient variance:", gradient_variance
@@ -382,35 +382,35 @@ contains
         real(dp) :: total_energy, kinetic_energy, potential_energy
         real(dp) :: energy_balance
         integer :: i
-        
+
         ! Test energy balance in finite element solution
         mesh = unit_square_mesh(5)
         Vh = function_space(mesh, "Lagrange", 1)
-        
+
         u = trial_function(Vh)
         v = test_function(Vh)
         f = constant(1.0_dp)
-        
+
         a = inner(grad(u), grad(v))*dx
         L = f*v*dx
-        
+
         bc = dirichlet_bc(Vh, 0.0_dp)
         uh = function(Vh)
-        
+
         call solve(a == L, uh, bc)
-        
+
         ! Compute approximate energy terms
         kinetic_energy = sum(uh%values**2) / real(Vh%ndof, dp)
-        
+
         potential_energy = 0.0_dp
         do i = 1, Vh%ndof-1
             potential_energy = potential_energy + (uh%values(i+1) - uh%values(i))**2
         end do
         potential_energy = potential_energy / real(Vh%ndof, dp)
-        
+
         total_energy = kinetic_energy + potential_energy
         energy_balance = abs(total_energy - kinetic_energy - potential_energy)
-        
+
         call check_condition(kinetic_energy >= 0.0_dp, &
             "Energy conservation: non-negative kinetic energy")
         call check_condition(potential_energy >= 0.0_dp, &
@@ -419,7 +419,7 @@ contains
             "Energy conservation: positive total energy")
         call check_condition(energy_balance < 1.0e-12_dp, &
             "Energy conservation: energy balance")
-        
+
         write(*,*) "   Kinetic energy:", kinetic_energy
         write(*,*) "   Potential energy:", potential_energy
         write(*,*) "   Total energy:", total_energy

--- a/test/test_super_removal_debug.f90
+++ b/test/test_super_removal_debug.f90
@@ -10,48 +10,48 @@ program test_super_removal_debug
     integer :: i, super_tri_idx, point_idx
     logical :: contains_super_vertex
     integer :: j, v, valid_count
-    
+
     write(*,*) "=== Super-Triangle Removal Debug ==="
-    
+
     ! Create simple triangle and run full Bowyer-Watson
     points(:, 1) = [0.0_dp, 0.0_dp]
     points(:, 2) = [1.0_dp, 0.0_dp]
     points(:, 3) = [0.5_dp, 1.0_dp]
-    
+
     call create_mesh(mesh, 6, 18, 9)
     call create_super_triangle(points, mesh, super_tri_idx)
-    
+
     do i = 1, 3
         point_idx = add_point(mesh, points(1, i), points(2, i), i)
     end do
-    
+
     do i = 4, mesh%npoints
         call insert_point(mesh, i)
     end do
-    
+
     write(*,*) "Super-triangle vertices:", mesh%super_vertices
     write(*,*) "Total triangles before removal:", mesh%ntriangles
-    
+
     ! Analyze each triangle
     valid_count = 0
     do i = 1, mesh%ntriangles
         if (.not. mesh%triangles(i)%valid) cycle
-        
+
         contains_super_vertex = .false.
         write(*,'(A,I0,A,3I0)', advance='no') "Triangle ", i, ": vertices=", mesh%triangles(i)%vertices
-        
+
         do j = 1, 3
             v = mesh%triangles(i)%vertices(j)
             if (any(mesh%super_vertices == v)) then
                 contains_super_vertex = .true.
             end if
         end do
-        
+
         write(*,'(A,3I0)', advance='no') " IDs=", &
             mesh%points(mesh%triangles(i)%vertices(1))%id, &
             mesh%points(mesh%triangles(i)%vertices(2))%id, &
             mesh%points(mesh%triangles(i)%vertices(3))%id
-            
+
         if (contains_super_vertex) then
             write(*,*) " [USES SUPER-TRIANGLE - REMOVE]"
         else
@@ -59,12 +59,12 @@ program test_super_removal_debug
             valid_count = valid_count + 1
         end if
     end do
-    
+
     write(*,*) "Triangles to keep:", valid_count
-    
+
     ! Now do actual removal
     call remove_super_triangle(mesh)
-    
+
     ! Count final valid triangles
     valid_count = 0
     do i = 1, mesh%ntriangles

--- a/test/test_triangle_comparison.f90
+++ b/test/test_triangle_comparison.f90
@@ -45,12 +45,12 @@ program test_triangle_comparison
     write(*,*) "3. Generating comparison plots..."
 
     call plot(fortfem_mesh, filename="build/comparison_fortfem.png",          &
-              title="FortFEM CDT")
+        title="FortFEM CDT")
     write(*,*) "   Saved: build/comparison_fortfem.png"
 
     if (triangle_ok) then
         call plot(triangle_mesh, filename="build/comparison_triangle.png",    &
-                  title="Triangle Library")
+            title="Triangle Library")
         write(*,*) "   Saved: build/comparison_triangle.png"
     end if
 
@@ -98,7 +98,7 @@ contains
 
         ! Write .poly file for Triangle
         call write_triangle_poly_file(POLY_FILE // ".poly", boundary%points,  &
-                                      segments, n, n, stat)
+            segments, n, n, stat)
         if (stat /= 0) then
             write(*,*) "   Warning: Failed to write .poly file"
             return

--- a/test/test_triangle_hole_comparison.f90
+++ b/test/test_triangle_hole_comparison.f90
@@ -11,27 +11,27 @@ program test_triangle_hole_comparison
     use fortfem_kinds, only : dp
     use fortfem_api,  only : mesh_t, mesh_from_arrays, mesh_from_triangle_files, plot
     use triangulation_fortran, only : triangulation_result_t,                 &
-                                      triangulate_with_hole_fortran
+        triangulate_with_hole_fortran
     use triangle_io, only : write_triangle_poly_file, ensure_triangle_available
     use check, only : check_condition, check_summary
     implicit none
 
     real(dp), parameter :: points(2,8) = reshape([ &
-        0.0_dp, 0.0_dp, &  ! outer square
+        0.0_dp, 0.0_dp, & ! outer square
         2.0_dp, 0.0_dp, &
         2.0_dp, 2.0_dp, &
         0.0_dp, 2.0_dp, &
-        0.5_dp, 0.5_dp, &  ! inner square (hole)
+        0.5_dp, 0.5_dp, & ! inner square (hole)
         1.5_dp, 0.5_dp, &
         1.5_dp, 1.5_dp, &
         0.5_dp, 1.5_dp ], [2, 8])
 
     integer, parameter :: segments(2,8) = reshape([ &
-        1, 2, &  ! outer segments
+        1, 2, & ! outer segments
         2, 3, &
         3, 4, &
         4, 1, &
-        5, 6, &  ! inner segments
+        5, 6, & ! inner segments
         6, 7, &
         7, 8, &
         8, 5 ], [2, 8])
@@ -68,12 +68,12 @@ program test_triangle_hole_comparison
     write(*,*) ""
     write(*,*) "=== Writing comparison plots ==="
     call plot(fortfem_mesh, filename="build/hole_fortfem.png",                &
-              title="FortFEM CDT with Hole")
+        title="FortFEM CDT with Hole")
     write(*,*) "   Saved: build/hole_fortfem.png"
 
     if (triangle_ok) then
         call plot(triangle_mesh, filename="build/hole_triangle.png",          &
-                  title="Triangle CDT with Hole")
+            title="Triangle CDT with Hole")
         write(*,*) "   Saved: build/hole_triangle.png"
     end if
 
@@ -123,7 +123,7 @@ contains
         hole_points(:,1) = hpt(:)
 
         call write_triangle_poly_file(POLY_FILE // ".poly", pts, segs,        &
-                                      n, size(segs,2), stat, hole_points)
+            n, size(segs,2), stat, hole_points)
         if (stat /= 0) then
             write(*,*) "   Warning: Failed to write .poly file with hole"
             return

--- a/test/test_triangle_intersection_comparison.f90
+++ b/test/test_triangle_intersection_comparison.f90
@@ -19,22 +19,22 @@ program test_triangle_intersection_comparison
     implicit none
 
     real(dp), parameter :: pts(2,8) = reshape([ &
-        0.0_dp, 0.0_dp, &  ! 1: outer square
-        2.0_dp, 0.0_dp, &  ! 2
-        2.0_dp, 2.0_dp, &  ! 3
-        0.0_dp, 2.0_dp, &  ! 4
-        0.0_dp, 1.0_dp, &  ! 5: mid left
-        2.0_dp, 1.0_dp, &  ! 6: mid right
-        1.0_dp, 0.0_dp, &  ! 7: mid bottom
-        1.0_dp, 2.0_dp ], [2, 8])  ! 8: mid top
+        0.0_dp, 0.0_dp, & ! 1: outer square
+        2.0_dp, 0.0_dp, & ! 2
+        2.0_dp, 2.0_dp, & ! 3
+        0.0_dp, 2.0_dp, & ! 4
+        0.0_dp, 1.0_dp, & ! 5: mid left
+        2.0_dp, 1.0_dp, & ! 6: mid right
+        1.0_dp, 0.0_dp, & ! 7: mid bottom
+        1.0_dp, 2.0_dp ], [2, 8]) ! 8: mid top
 
     integer, parameter :: segs(2,6) = reshape([ &
-        1, 2, &  ! outer square
+        1, 2, & ! outer square
         2, 3, &
         3, 4, &
         4, 1, &
-        5, 6, &  ! horizontal
-        7, 8 ], [2, 6])   ! vertical
+        5, 6, & ! horizontal
+        7, 8 ], [2, 6]) ! vertical
 
     type(triangulation_result_t) :: fortfem_result
     type(mesh_t) :: fortfem_mesh, triangle_mesh
@@ -64,12 +64,12 @@ program test_triangle_intersection_comparison
     write(*,*) ""
     write(*,*) "=== Writing intersection comparison plots ==="
     call plot(fortfem_mesh, filename="build/intersection_fortfem.png",        &
-              title="FortFEM CDT with Segment Intersection")
+        title="FortFEM CDT with Segment Intersection")
     write(*,*) "   Saved: build/intersection_fortfem.png"
 
     if (triangle_ok) then
         call plot(triangle_mesh, filename="build/intersection_triangle.png",  &
-                  title="Triangle CDT with Segment Intersection")
+            title="Triangle CDT with Segment Intersection")
         write(*,*) "   Saved: build/intersection_triangle.png"
     end if
 
@@ -113,7 +113,7 @@ contains
         nsegs  = size(segments, 2)
 
         call write_triangle_poly_file(POLY_FILE // ".poly", points, segments, &
-                                      nverts, nsegs, stat)
+            nverts, nsegs, stat)
         if (stat /= 0) then
             write(*,*) "   Warning: failed to write .poly for intersection test"
             return

--- a/test/test_triangle_quality_comparison.f90
+++ b/test/test_triangle_quality_comparison.f90
@@ -15,23 +15,23 @@ program test_triangle_quality_comparison
     !
     use fortfem_kinds, only : dp
     use fortfem_api,  only : mesh_t, mesh_from_arrays, mesh_from_triangle_files, &
-                             plot
+        plot
     use triangulation_fortran, only : triangulation_result_t,                   &
-                                      triangulate_fortran,                      &
-                                      triangulate_with_quality_fortran
+        triangulate_fortran,                      &
+        triangulate_with_quality_fortran
     use triangle_io, only : write_triangle_poly_file, ensure_triangle_available
     use check, only : check_condition, check_summary
     implicit none
 
     real(dp), parameter :: points(2,5) = reshape([ &
-        0.0_dp, 0.0_dp, &  ! 1: outer square
-        2.0_dp, 0.0_dp, &  ! 2
-        2.0_dp, 2.0_dp, &  ! 3
-        0.0_dp, 2.0_dp, &  ! 4
-        0.5_dp, 0.15_dp ], [2, 5])  ! 5: interior point near lower edge
+        0.0_dp, 0.0_dp, & ! 1: outer square
+        2.0_dp, 0.0_dp, & ! 2
+        2.0_dp, 2.0_dp, & ! 3
+        0.0_dp, 2.0_dp, & ! 4
+        0.5_dp, 0.15_dp ], [2, 5]) ! 5: interior point near lower edge
 
     integer, parameter :: segments(2,4) = reshape([ &
-        1, 2, &  ! outer boundary
+        1, 2, & ! outer boundary
         2, 3, &
         3, 4, &
         4, 1 ], [2, 4])
@@ -85,16 +85,16 @@ program test_triangle_quality_comparison
     write(*,*) ""
     write(*,*) "=== Writing quality comparison plots ==="
     call plot(base_mesh, filename="build/quality_base_fortfem.png",          &
-              title="FortFEM Base CDT")
+        title="FortFEM Base CDT")
     write(*,*) "   Saved: build/quality_base_fortfem.png"
 
     call plot(quality_mesh, filename="build/quality_refined_fortfem.png",    &
-              title="FortFEM Quality CDT")
+        title="FortFEM Quality CDT")
     write(*,*) "   Saved: build/quality_refined_fortfem.png"
 
     if (triangle_ok) then
         call plot(triangle_mesh, filename="build/quality_triangle.png",      &
-                  title="Triangle Quality CDT")
+            title="Triangle Quality CDT")
         write(*,*) "   Saved: build/quality_triangle.png"
     end if
 
@@ -117,7 +117,7 @@ contains
     end subroutine run_fortfem_base
 
     subroutine run_fortfem_quality(pts, segs, min_angle_target, result,      &
-                                   mesh, min_angle_deg, status)
+            mesh, min_angle_deg, status)
         real(dp), intent(in) :: pts(:,:)
         integer, intent(in) :: segs(:,:)
         real(dp), intent(in) :: min_angle_target
@@ -127,13 +127,13 @@ contains
         integer, intent(out) :: status
 
         call triangulate_with_quality_fortran(pts, segs, min_angle_target,   &
-                                             result, status)
+            result, status)
         mesh = mesh_from_arrays(result%points, result%triangles)
         min_angle_deg = compute_min_result_angle(result)
     end subroutine run_fortfem_quality
 
     subroutine run_triangle_quality(pts, segs, min_angle_target, mesh,       &
-                                    min_angle_deg, success)
+            min_angle_deg, success)
         real(dp), intent(in) :: pts(:,:)
         integer, intent(in) :: segs(:,:)
         real(dp), intent(in) :: min_angle_target
@@ -156,14 +156,14 @@ contains
         nsegs  = size(segs, 2)
 
         call write_triangle_poly_file(POLY_FILE // ".poly", pts, segs,       &
-                                      nverts, nsegs, stat)
+            nverts, nsegs, stat)
         if (stat /= 0) then
             write(*,*) "   Warning: failed to write .poly for quality test"
             return
         end if
 
         call run_triangle_binary_quality(TRIANGLE_PATH, POLY_FILE,           &
-                                         min_angle_target, stat)
+            min_angle_target, stat)
         if (stat /= 0) then
             write(*,*) "   Warning: Triangle execution failed for quality test"
             return
@@ -182,7 +182,7 @@ contains
     end subroutine run_triangle_quality
 
     subroutine run_triangle_binary_quality(bin_path, poly_basename,          &
-                                           min_angle_deg, exit_stat)
+            min_angle_deg, exit_stat)
         character(len=*), intent(in) :: bin_path
         character(len=*), intent(in) :: poly_basename
         real(dp), intent(in) :: min_angle_deg
@@ -215,7 +215,7 @@ contains
             cy = result%points(2, result%triangles(3, i))
 
             call triangle_angles_from_coords(ax, ay, bx, by, cx, cy,         &
-                                            angle1, angle2, angle3, pi)
+                angle1, angle2, angle3, pi)
 
             tri_min = min(angle1, min(angle2, angle3))
             if (tri_min < min_angle_deg) min_angle_deg = tri_min
@@ -245,7 +245,7 @@ contains
             cy = mesh%data%vertices(2, v3)
 
             call triangle_angles_from_coords(ax, ay, bx, by, cx, cy,         &
-                                            angle1, angle2, angle3, pi)
+                angle1, angle2, angle3, pi)
 
             tri_min = min(angle1, min(angle2, angle3))
             if (tri_min < min_angle_deg) min_angle_deg = tri_min
@@ -253,7 +253,7 @@ contains
     end function compute_min_mesh_angle
 
     subroutine triangle_angles_from_coords(ax, ay, bx, by, cx, cy,           &
-                                           angle1, angle2, angle3, pi)
+            angle1, angle2, angle3, pi)
         real(dp), intent(in) :: ax, ay, bx, by, cx, cy, pi
         real(dp), intent(out) :: angle1, angle2, angle3
 

--- a/test/test_triangulation_mephit.f90
+++ b/test/test_triangulation_mephit.f90
@@ -4,13 +4,13 @@ program test_triangulation_mephit
     use geometric_predicates
     use triangulation_fortran
     implicit none
-    
+
     ! Test framework
     integer :: test_count = 0
     integer :: passed_tests = 0
-    
+
     write(*,*) '=== MEPHIT Triangulation Tests ==='
-    
+
     ! Test suite
     call test_data_structures()
     call test_geometric_predicates()
@@ -20,9 +20,9 @@ program test_triangulation_mephit
     call test_complex_boundary()
     call test_quality_constraints()
     call test_edge_cases()
-    
+
     ! Summary
-    write(*,*) 
+    write(*,*)
     write(*,'(A,I0,A,I0,A)') 'Tests passed: ', passed_tests, '/', test_count
     if (passed_tests == test_count) then
         write(*,*) 'All tests passed!'
@@ -30,423 +30,423 @@ program test_triangulation_mephit
         write(*,*) 'Some tests failed!'
         stop 1
     end if
-    
+
 contains
 
-subroutine test_data_structures()
-    character(len=*), parameter :: test_name = 'Data Structures'
-    type(mesh_t) :: mesh
-    integer :: p1, p2, p3, t1, e1
-    
-    call start_test(test_name)
-    
-    ! Test mesh creation
-    call create_mesh(mesh, 100, 200, 150)
-    call assert_equal(mesh%max_points, 100, 'Max points set correctly')
-    call assert_equal(mesh%max_triangles, 200, 'Max triangles set correctly')
-    call assert_equal(mesh%max_edges, 150, 'Max edges set correctly')
-    call assert_equal(mesh%npoints, 0, 'Initial point count is zero')
-    
-    ! Test point addition
-    p1 = add_point(mesh, 0.0_dp, 0.0_dp, 1)
-    p2 = add_point(mesh, 1.0_dp, 0.0_dp, 2)
-    p3 = add_point(mesh, 0.5_dp, 0.866_dp, 3)
-    
-    call assert_equal(mesh%npoints, 3, 'Three points added')
-    call assert_equal(p1, 1, 'First point index')
-    call assert_equal(p2, 2, 'Second point index')
-    call assert_equal(p3, 3, 'Third point index')
-    
-    ! Test triangle addition
-    t1 = add_triangle(mesh, p1, p2, p3)
-    call assert_equal(mesh%ntriangles, 1, 'One triangle added')
-    call assert_equal(t1, 1, 'Triangle index')
-    call assert_true(is_valid_triangle(mesh, t1), 'Triangle is valid')
-    
-    ! Test edge addition
-    e1 = add_edge(mesh, p1, p2, .true.)
-    call assert_equal(mesh%nedges, 1, 'One edge added')
-    call assert_equal(e1, 1, 'Edge index')
-    call assert_true(is_valid_edge(mesh, e1), 'Edge is valid')
-    call assert_true(mesh%edges(e1)%constrained, 'Edge is constrained')
-    
-    ! Test mesh resizing
-    call resize_mesh(mesh, 200, 400, 300)
-    call assert_equal(mesh%max_points, 200, 'Points resized')
-    call assert_equal(mesh%max_triangles, 400, 'Triangles resized')
-    call assert_equal(mesh%max_edges, 300, 'Edges resized')
-    call assert_equal(mesh%npoints, 3, 'Point count preserved')
-    
-    call destroy_mesh(mesh)
-    call end_test()
-end subroutine
+    subroutine test_data_structures()
+        character(len=*), parameter :: test_name = 'Data Structures'
+        type(mesh_t) :: mesh
+        integer :: p1, p2, p3, t1, e1
 
-subroutine test_geometric_predicates()
-    character(len=*), parameter :: test_name = 'Geometric Predicates'
-    type(point_t) :: pa, pb, pc, pd
-    type(mesh_t) :: mesh
-    integer :: t1, orient_result, p1, p2, p3
-    real(dp) :: area
-    
-    call start_test(test_name)
-    
-    ! Set up test points
-    pa = point_t(0.0_dp, 0.0_dp, 1, .true.)
-    pb = point_t(1.0_dp, 0.0_dp, 2, .true.)
-    pc = point_t(0.5_dp, 0.866_dp, 3, .true.)
-    pd = point_t(0.5_dp, 0.3_dp, 4, .true.)
-    
-    ! Test orientation
-    orient_result = orientation(pa, pb, pc)
-    call assert_equal(orient_result, ORIENTATION_CCW, 'CCW orientation')
-    
-    orient_result = orientation(pa, pc, pb)
-    call assert_equal(orient_result, ORIENTATION_CW, 'CW orientation')
-    
-    orient_result = orientation(pa, pb, point_t(0.5_dp, 0.0_dp, 5, .true.))
-    call assert_equal(orient_result, ORIENTATION_COLLINEAR, 'Collinear points')
-    
-    ! Test in_circle
-    call assert_true(in_circle(pa, pb, pc, pd), 'Point inside circumcircle')
-    
-    pd = point_t(2.0_dp, 2.0_dp, 4, .true.)
-    call assert_false(in_circle(pa, pb, pc, pd), 'Point outside circumcircle')
-    
-    ! Test triangle area
-    area = triangle_area(pa, pb, pc)
-    call assert_approx_equal(area, 0.433_dp, 0.001_dp, 'Triangle area')
-    
-    ! Test point in triangle
-    call create_mesh(mesh, 10, 10, 10)
-    p1 = add_point(mesh, 0.0_dp, 0.0_dp, 1)
-    p2 = add_point(mesh, 1.0_dp, 0.0_dp, 2)
-    p3 = add_point(mesh, 0.5_dp, 0.866_dp, 3)
-    t1 = add_triangle(mesh, p1, p2, p3)
-    
-    pd = point_t(0.4_dp, 0.2_dp, 4, .true.)  ! Point clearly inside
-    call assert_true(point_in_triangle(pd, mesh, t1), 'Point inside triangle')
-    
-    pd = point_t(0.0_dp, 1.0_dp, 4, .true.)  ! Point clearly outside
-    call assert_false(point_in_triangle(pd, mesh, t1), 'Point outside triangle')
-    
-    call destroy_mesh(mesh)
-    call end_test()
-end subroutine
+        call start_test(test_name)
 
-subroutine test_simple_triangle()
-    character(len=*), parameter :: test_name = 'Simple Triangle'
-    type(mesh_t) :: mesh
-    type(point_t) :: pa, pb, pc
-    integer :: p1, p2, p3, t1
-    real(dp) :: area
-    
-    call start_test(test_name)
-    
-    ! Create a simple triangle mesh
-    call create_mesh(mesh, 10, 10, 10)
-    
-    ! Add triangle vertices
-    p1 = add_point(mesh, 0.0_dp, 0.0_dp, 1)
-    p2 = add_point(mesh, 1.0_dp, 0.0_dp, 2)
-    p3 = add_point(mesh, 0.5_dp, 0.866_dp, 3)
-    
-    ! Add triangle
-    t1 = add_triangle(mesh, p1, p2, p3)
-    
-    ! Test triangle properties
-    call assert_equal(mesh%npoints, 3, 'Number of points')
-    call assert_equal(mesh%ntriangles, 1, 'Number of triangles')
-    call assert_true(is_valid_triangle(mesh, t1), 'Triangle is valid')
-    
-    ! Test triangle area
-    pa = mesh%points(p1)
-    pb = mesh%points(p2)
-    pc = mesh%points(p3)
-    area = triangle_area(pa, pb, pc)
-    call assert_approx_equal(area, 0.433_dp, 0.001_dp, 'Triangle area')
-    
-    ! Test orientation (should be CCW)
-    call assert_equal(orientation(pa, pb, pc), ORIENTATION_CCW, 'CCW orientation')
-    
-    call destroy_mesh(mesh)
-    call end_test()
-end subroutine
+        ! Test mesh creation
+        call create_mesh(mesh, 100, 200, 150)
+        call assert_equal(mesh%max_points, 100, 'Max points set correctly')
+        call assert_equal(mesh%max_triangles, 200, 'Max triangles set correctly')
+        call assert_equal(mesh%max_edges, 150, 'Max edges set correctly')
+        call assert_equal(mesh%npoints, 0, 'Initial point count is zero')
 
-subroutine test_bowyer_watson()
-    character(len=*), parameter :: test_name = 'Bowyer-Watson Algorithm'
-    real(dp), parameter :: points(2,4) = reshape([&
-        0.0_dp, 0.0_dp, &
-        1.0_dp, 0.0_dp, &
-        1.0_dp, 1.0_dp, &
-        0.0_dp, 1.0_dp], [2, 4])
-    integer, parameter :: segments(2,4) = reshape([&
-        1, 2, &
-        2, 3, &
-        3, 4, &
-        4, 1], [2, 4])
-    
-    type(triangulation_result_t) :: result
-    
-    call start_test(test_name)
-    
-    ! Test Bowyer-Watson triangulation
-    call triangulate_fortran(points, segments, result)
-    
-    ! Basic validation
-    write(*,'(A,I0)') '  Points: ', result%npoints
-    write(*,'(A,I0)') '  Triangles: ', result%ntriangles
-    write(*,'(A,I0)') '  Segments: ', result%nsegments
-    
-    ! Should have 4 points
-    call assert_equal(result%npoints, 4, 'Number of points')
-    
-    ! Note: Unconstrained Delaunay gives convex hull (1 triangle for 4 coplanar points)
-    ! Need constrained Delaunay for proper boundary preservation
-    call assert_true(result%ntriangles >= 1, 'At least 1 triangle')
-    
-    ! Should have 4 segments
-    call assert_equal(result%nsegments, 4, 'Number of segments')
-    
-    ! Check that all triangles are valid (positive area)
-    call assert_true(all_triangles_valid(result), 'All triangles have positive area')
-    
-    call cleanup_triangulation(result)
-    call end_test()
-end subroutine
+        ! Test point addition
+        p1 = add_point(mesh, 0.0_dp, 0.0_dp, 1)
+        p2 = add_point(mesh, 1.0_dp, 0.0_dp, 2)
+        p3 = add_point(mesh, 0.5_dp, 0.866_dp, 3)
 
-logical function all_triangles_valid(result)
-    type(triangulation_result_t), intent(in) :: result
-    integer :: i
-    real(dp) :: area
-    
-    all_triangles_valid = .true.
-    do i = 1, result%ntriangles
-        ! Check for valid vertex indices first
-        if (any(result%triangles(:, i) < 1) .or. any(result%triangles(:, i) > result%npoints)) then
-            write(*,'(A,I0,A,3I0,A,I0)') '  Invalid vertex indices in triangle ', i, ': ', &
-                result%triangles(:, i), ' (max valid: ', result%npoints, ')'
-            all_triangles_valid = .false.
-            return
+        call assert_equal(mesh%npoints, 3, 'Three points added')
+        call assert_equal(p1, 1, 'First point index')
+        call assert_equal(p2, 2, 'Second point index')
+        call assert_equal(p3, 3, 'Third point index')
+
+        ! Test triangle addition
+        t1 = add_triangle(mesh, p1, p2, p3)
+        call assert_equal(mesh%ntriangles, 1, 'One triangle added')
+        call assert_equal(t1, 1, 'Triangle index')
+        call assert_true(is_valid_triangle(mesh, t1), 'Triangle is valid')
+
+        ! Test edge addition
+        e1 = add_edge(mesh, p1, p2, .true.)
+        call assert_equal(mesh%nedges, 1, 'One edge added')
+        call assert_equal(e1, 1, 'Edge index')
+        call assert_true(is_valid_edge(mesh, e1), 'Edge is valid')
+        call assert_true(mesh%edges(e1)%constrained, 'Edge is constrained')
+
+        ! Test mesh resizing
+        call resize_mesh(mesh, 200, 400, 300)
+        call assert_equal(mesh%max_points, 200, 'Points resized')
+        call assert_equal(mesh%max_triangles, 400, 'Triangles resized')
+        call assert_equal(mesh%max_edges, 300, 'Edges resized')
+        call assert_equal(mesh%npoints, 3, 'Point count preserved')
+
+        call destroy_mesh(mesh)
+        call end_test()
+    end subroutine
+
+    subroutine test_geometric_predicates()
+        character(len=*), parameter :: test_name = 'Geometric Predicates'
+        type(point_t) :: pa, pb, pc, pd
+        type(mesh_t) :: mesh
+        integer :: t1, orient_result, p1, p2, p3
+        real(dp) :: area
+
+        call start_test(test_name)
+
+        ! Set up test points
+        pa = point_t(0.0_dp, 0.0_dp, 1, .true.)
+        pb = point_t(1.0_dp, 0.0_dp, 2, .true.)
+        pc = point_t(0.5_dp, 0.866_dp, 3, .true.)
+        pd = point_t(0.5_dp, 0.3_dp, 4, .true.)
+
+        ! Test orientation
+        orient_result = orientation(pa, pb, pc)
+        call assert_equal(orient_result, ORIENTATION_CCW, 'CCW orientation')
+
+        orient_result = orientation(pa, pc, pb)
+        call assert_equal(orient_result, ORIENTATION_CW, 'CW orientation')
+
+        orient_result = orientation(pa, pb, point_t(0.5_dp, 0.0_dp, 5, .true.))
+        call assert_equal(orient_result, ORIENTATION_COLLINEAR, 'Collinear points')
+
+        ! Test in_circle
+        call assert_true(in_circle(pa, pb, pc, pd), 'Point inside circumcircle')
+
+        pd = point_t(2.0_dp, 2.0_dp, 4, .true.)
+        call assert_false(in_circle(pa, pb, pc, pd), 'Point outside circumcircle')
+
+        ! Test triangle area
+        area = triangle_area(pa, pb, pc)
+        call assert_approx_equal(area, 0.433_dp, 0.001_dp, 'Triangle area')
+
+        ! Test point in triangle
+        call create_mesh(mesh, 10, 10, 10)
+        p1 = add_point(mesh, 0.0_dp, 0.0_dp, 1)
+        p2 = add_point(mesh, 1.0_dp, 0.0_dp, 2)
+        p3 = add_point(mesh, 0.5_dp, 0.866_dp, 3)
+        t1 = add_triangle(mesh, p1, p2, p3)
+
+        pd = point_t(0.4_dp, 0.2_dp, 4, .true.) ! Point clearly inside
+        call assert_true(point_in_triangle(pd, mesh, t1), 'Point inside triangle')
+
+        pd = point_t(0.0_dp, 1.0_dp, 4, .true.) ! Point clearly outside
+        call assert_false(point_in_triangle(pd, mesh, t1), 'Point outside triangle')
+
+        call destroy_mesh(mesh)
+        call end_test()
+    end subroutine
+
+    subroutine test_simple_triangle()
+        character(len=*), parameter :: test_name = 'Simple Triangle'
+        type(mesh_t) :: mesh
+        type(point_t) :: pa, pb, pc
+        integer :: p1, p2, p3, t1
+        real(dp) :: area
+
+        call start_test(test_name)
+
+        ! Create a simple triangle mesh
+        call create_mesh(mesh, 10, 10, 10)
+
+        ! Add triangle vertices
+        p1 = add_point(mesh, 0.0_dp, 0.0_dp, 1)
+        p2 = add_point(mesh, 1.0_dp, 0.0_dp, 2)
+        p3 = add_point(mesh, 0.5_dp, 0.866_dp, 3)
+
+        ! Add triangle
+        t1 = add_triangle(mesh, p1, p2, p3)
+
+        ! Test triangle properties
+        call assert_equal(mesh%npoints, 3, 'Number of points')
+        call assert_equal(mesh%ntriangles, 1, 'Number of triangles')
+        call assert_true(is_valid_triangle(mesh, t1), 'Triangle is valid')
+
+        ! Test triangle area
+        pa = mesh%points(p1)
+        pb = mesh%points(p2)
+        pc = mesh%points(p3)
+        area = triangle_area(pa, pb, pc)
+        call assert_approx_equal(area, 0.433_dp, 0.001_dp, 'Triangle area')
+
+        ! Test orientation (should be CCW)
+        call assert_equal(orientation(pa, pb, pc), ORIENTATION_CCW, 'CCW orientation')
+
+        call destroy_mesh(mesh)
+        call end_test()
+    end subroutine
+
+    subroutine test_bowyer_watson()
+        character(len=*), parameter :: test_name = 'Bowyer-Watson Algorithm'
+        real(dp), parameter :: points(2,4) = reshape([&
+            0.0_dp, 0.0_dp, &
+            1.0_dp, 0.0_dp, &
+            1.0_dp, 1.0_dp, &
+            0.0_dp, 1.0_dp], [2, 4])
+        integer, parameter :: segments(2,4) = reshape([&
+            1, 2, &
+            2, 3, &
+            3, 4, &
+            4, 1], [2, 4])
+
+        type(triangulation_result_t) :: result
+
+        call start_test(test_name)
+
+        ! Test Bowyer-Watson triangulation
+        call triangulate_fortran(points, segments, result)
+
+        ! Basic validation
+        write(*,'(A,I0)') '  Points: ', result%npoints
+        write(*,'(A,I0)') '  Triangles: ', result%ntriangles
+        write(*,'(A,I0)') '  Segments: ', result%nsegments
+
+        ! Should have 4 points
+        call assert_equal(result%npoints, 4, 'Number of points')
+
+        ! Note: Unconstrained Delaunay gives convex hull (1 triangle for 4 coplanar points)
+        ! Need constrained Delaunay for proper boundary preservation
+        call assert_true(result%ntriangles >= 1, 'At least 1 triangle')
+
+        ! Should have 4 segments
+        call assert_equal(result%nsegments, 4, 'Number of segments')
+
+        ! Check that all triangles are valid (positive area)
+        call assert_true(all_triangles_valid(result), 'All triangles have positive area')
+
+        call cleanup_triangulation(result)
+        call end_test()
+    end subroutine
+
+    logical function all_triangles_valid(result)
+        type(triangulation_result_t), intent(in) :: result
+        integer :: i
+        real(dp) :: area
+
+        all_triangles_valid = .true.
+        do i = 1, result%ntriangles
+            ! Check for valid vertex indices first
+            if (any(result%triangles(:, i) < 1) .or. any(result%triangles(:, i) > result%npoints)) then
+                write(*,'(A,I0,A,3I0,A,I0)') '  Invalid vertex indices in triangle ', i, ': ', &
+                    result%triangles(:, i), ' (max valid: ', result%npoints, ')'
+                all_triangles_valid = .false.
+                return
+            end if
+
+            area = compute_triangle_area(result%points, result%triangles(:, i))
+            if (area <= 0.0_dp) then
+                write(*,'(A,I0,A,ES15.8)') '  Triangle ', i, ' has invalid area: ', area
+                all_triangles_valid = .false.
+                return
+            end if
+        end do
+    end function all_triangles_valid
+
+    real(dp) function compute_triangle_area(points, triangle)
+        real(dp), intent(in) :: points(:,:)
+        integer, intent(in) :: triangle(3)
+        real(dp) :: x1, y1, x2, y2, x3, y3
+
+        x1 = points(1, triangle(1))
+        y1 = points(2, triangle(1))
+        x2 = points(1, triangle(2))
+        y2 = points(2, triangle(2))
+        x3 = points(1, triangle(3))
+        y3 = points(2, triangle(3))
+
+        compute_triangle_area = 0.5_dp * abs((x1*(y2-y3) + x2*(y3-y1) + x3*(y1-y2)))
+    end function compute_triangle_area
+
+    subroutine test_square_with_hole()
+        character(len=*), parameter :: test_name = 'Square with Hole'
+        ! Simple square with hole test
+        real(dp), parameter :: points(2,8) = reshape([&
+            0.0_dp, 0.0_dp, & ! outer square
+            2.0_dp, 0.0_dp, &
+            2.0_dp, 2.0_dp, &
+            0.0_dp, 2.0_dp, &
+            0.5_dp, 0.5_dp, & ! inner square (will be hole)
+            1.5_dp, 0.5_dp, &
+            1.5_dp, 1.5_dp, &
+            0.5_dp, 1.5_dp], [2, 8])
+        integer, parameter :: segments(2,8) = reshape([&
+            1, 2, & ! outer segments
+            2, 3, &
+            3, 4, &
+            4, 1, &
+            5, 6, & ! inner segments
+            6, 7, &
+            7, 8, &
+            8, 5], [2, 8])
+
+        type(triangulation_result_t) :: result
+        integer :: i
+
+        call start_test(test_name)
+
+        ! Test constrained triangulation (without hole processing yet)
+        call triangulate_fortran(points, segments, result)
+
+        ! Should have 8 points
+        call assert_equal(result%npoints, 8, 'Number of points')
+
+        ! Should have triangles
+        call assert_true(result%ntriangles > 0, 'Has triangles')
+
+        ! Should have 8 segments
+        call assert_equal(result%nsegments, 8, 'Number of segments')
+
+        ! All triangles should have positive area
+        if (all_triangles_valid(result)) then
+            write(*,*) '  All triangles are valid'
+        else
+            write(*,*) '  Some triangles are invalid (expected for complex test)'
         end if
-        
-        area = compute_triangle_area(result%points, result%triangles(:, i))
-        if (area <= 0.0_dp) then
-            write(*,'(A,I0,A,ES15.8)') '  Triangle ', i, ' has invalid area: ', area
-            all_triangles_valid = .false.
-            return
+
+        call cleanup_triangulation(result)
+        call end_test()
+    end subroutine
+
+    subroutine test_complex_boundary()
+        character(len=*), parameter :: test_name = 'Complex Boundary'
+        ! L-shaped domain boundary (6 vertices, proper closed boundary)
+        real(dp), parameter :: points(2,6) = reshape([&
+            0.0_dp, 0.0_dp, & ! corner points of L-shape
+            2.0_dp, 0.0_dp, &
+            2.0_dp, 1.0_dp, &
+            1.0_dp, 1.0_dp, &
+            1.0_dp, 2.0_dp, &
+            0.0_dp, 2.0_dp], [2, 6])
+        integer, parameter :: segments(2,6) = reshape([&
+            1, 2, & ! L-shaped boundary (closed)
+            2, 3, &
+            3, 4, &
+            4, 5, &
+            5, 6, &
+            6, 1], [2, 6])
+
+        type(triangulation_result_t) :: result
+
+        call start_test(test_name)
+
+        ! Test complex boundary with constrained triangulation
+        call triangulate_fortran(points, segments, result)
+
+        ! Should have 6 points
+        call assert_equal(result%npoints, 6, 'Number of points')
+
+        ! Should have triangles (L-shape with 6 vertices makes 4 triangles)
+        call assert_true(result%ntriangles > 0, 'Has triangles')
+
+        ! Should have 6 segments
+        call assert_equal(result%nsegments, 6, 'Number of segments')
+
+        ! All triangles should have positive area
+        if (all_triangles_valid(result)) then
+            write(*,*) '  All triangles are valid'
+        else
+            write(*,*) '  Some triangles are invalid'
         end if
-    end do
-end function all_triangles_valid
 
-real(dp) function compute_triangle_area(points, triangle)
-    real(dp), intent(in) :: points(:,:)
-    integer, intent(in) :: triangle(3)
-    real(dp) :: x1, y1, x2, y2, x3, y3
-    
-    x1 = points(1, triangle(1))
-    y1 = points(2, triangle(1))
-    x2 = points(1, triangle(2))
-    y2 = points(2, triangle(2))
-    x3 = points(1, triangle(3))
-    y3 = points(2, triangle(3))
-    
-    compute_triangle_area = 0.5_dp * abs((x1*(y2-y3) + x2*(y3-y1) + x3*(y1-y2)))
-end function compute_triangle_area
+        call cleanup_triangulation(result)
+        call end_test()
+    end subroutine
 
-subroutine test_square_with_hole()
-    character(len=*), parameter :: test_name = 'Square with Hole'
-    ! Simple square with hole test
-    real(dp), parameter :: points(2,8) = reshape([&
-        0.0_dp, 0.0_dp, &  ! outer square
-        2.0_dp, 0.0_dp, &
-        2.0_dp, 2.0_dp, &
-        0.0_dp, 2.0_dp, &
-        0.5_dp, 0.5_dp, &  ! inner square (will be hole)
-        1.5_dp, 0.5_dp, &
-        1.5_dp, 1.5_dp, &
-        0.5_dp, 1.5_dp], [2, 8])
-    integer, parameter :: segments(2,8) = reshape([&
-        1, 2, &  ! outer segments
-        2, 3, &
-        3, 4, &
-        4, 1, &
-        5, 6, &  ! inner segments
-        6, 7, &
-        7, 8, &
-        8, 5], [2, 8])
-    
-    type(triangulation_result_t) :: result
-    integer :: i
-    
-    call start_test(test_name)
-    
-    ! Test constrained triangulation (without hole processing yet)
-    call triangulate_fortran(points, segments, result)
-    
-    ! Should have 8 points
-    call assert_equal(result%npoints, 8, 'Number of points')
-    
-    ! Should have triangles
-    call assert_true(result%ntriangles > 0, 'Has triangles')
-    
-    ! Should have 8 segments
-    call assert_equal(result%nsegments, 8, 'Number of segments')
-    
-    ! All triangles should have positive area
-    if (all_triangles_valid(result)) then
-        write(*,*) '  All triangles are valid'
-    else
-        write(*,*) '  Some triangles are invalid (expected for complex test)'
-    end if
-    
-    call cleanup_triangulation(result)
-    call end_test()
-end subroutine
+    subroutine test_quality_constraints()
+        character(len=*), parameter :: test_name = 'Quality Constraints'
+        ! Simple quality check on a unit square domain
+        real(dp), parameter :: points(2,4) = reshape([&
+            0.0_dp, 0.0_dp, &
+            1.0_dp, 0.0_dp, &
+            1.0_dp, 1.0_dp, &
+            0.0_dp, 1.0_dp], [2, 4])
+        integer, parameter :: segments(2,4) = reshape([&
+            1, 2, &
+            2, 3, &
+            3, 4, &
+            4, 1], [2, 4])
 
-subroutine test_complex_boundary()
-    character(len=*), parameter :: test_name = 'Complex Boundary'
-    ! L-shaped domain boundary (6 vertices, proper closed boundary)
-    real(dp), parameter :: points(2,6) = reshape([&
-        0.0_dp, 0.0_dp, &  ! corner points of L-shape
-        2.0_dp, 0.0_dp, &
-        2.0_dp, 1.0_dp, &
-        1.0_dp, 1.0_dp, &
-        1.0_dp, 2.0_dp, &
-        0.0_dp, 2.0_dp], [2, 6])
-    integer, parameter :: segments(2,6) = reshape([&
-        1, 2, &  ! L-shaped boundary (closed)
-        2, 3, &
-        3, 4, &
-        4, 5, &
-        5, 6, &
-        6, 1], [2, 6])
+        type(triangulation_result_t) :: result
+        integer :: status
 
-    type(triangulation_result_t) :: result
+        call start_test(test_name)
 
-    call start_test(test_name)
+        call triangulate_with_quality_fortran(points, segments, 10.0_dp, result, status)
 
-    ! Test complex boundary with constrained triangulation
-    call triangulate_fortran(points, segments, result)
+        call assert_true(status == 0, 'Quality constraints: acceptable minimum angle')
+        call assert_true(all_triangles_valid(result), 'Quality constraints: valid triangles')
 
-    ! Should have 6 points
-    call assert_equal(result%npoints, 6, 'Number of points')
+        call cleanup_triangulation(result)
+        call end_test()
+    end subroutine
 
-    ! Should have triangles (L-shape with 6 vertices makes 4 triangles)
-    call assert_true(result%ntriangles > 0, 'Has triangles')
+    subroutine test_edge_cases()
+        character(len=*), parameter :: test_name = 'Edge Cases'
+        type(point_t) :: pa, pb, pc
 
-    ! Should have 6 segments
-    call assert_equal(result%nsegments, 6, 'Number of segments')
+        call start_test(test_name)
 
-    ! All triangles should have positive area
-    if (all_triangles_valid(result)) then
-        write(*,*) '  All triangles are valid'
-    else
-        write(*,*) '  Some triangles are invalid'
-    end if
+        ! Test collinear points
+        pa = point_t(0.0_dp, 0.0_dp, 1, .true.)
+        pb = point_t(1.0_dp, 0.0_dp, 2, .true.)
+        pc = point_t(2.0_dp, 0.0_dp, 3, .true.)
 
-    call cleanup_triangulation(result)
-    call end_test()
-end subroutine
+        call assert_equal(orientation(pa, pb, pc), ORIENTATION_COLLINEAR, 'Collinear detection')
 
-subroutine test_quality_constraints()
-    character(len=*), parameter :: test_name = 'Quality Constraints'
-    ! Simple quality check on a unit square domain
-    real(dp), parameter :: points(2,4) = reshape([&
-        0.0_dp, 0.0_dp, &
-        1.0_dp, 0.0_dp, &
-        1.0_dp, 1.0_dp, &
-        0.0_dp, 1.0_dp], [2, 4])
-    integer, parameter :: segments(2,4) = reshape([&
-        1, 2, &
-        2, 3, &
-        3, 4, &
-        4, 1], [2, 4])
-    
-    type(triangulation_result_t) :: result
-    integer :: status
-    
-    call start_test(test_name)
-    
-    call triangulate_with_quality_fortran(points, segments, 10.0_dp, result, status)
-    
-    call assert_true(status == 0, 'Quality constraints: acceptable minimum angle')
-    call assert_true(all_triangles_valid(result), 'Quality constraints: valid triangles')
-    
-    call cleanup_triangulation(result)
-    call end_test()
-end subroutine
+        ! Test very small triangle
+        pa = point_t(0.0_dp, 0.0_dp, 1, .true.)
+        pb = point_t(1e-15_dp, 0.0_dp, 2, .true.)
+        pc = point_t(0.0_dp, 1e-15_dp, 3, .true.)
 
-subroutine test_edge_cases()
-    character(len=*), parameter :: test_name = 'Edge Cases'
-    type(point_t) :: pa, pb, pc
-    
-    call start_test(test_name)
-    
-    ! Test collinear points
-    pa = point_t(0.0_dp, 0.0_dp, 1, .true.)
-    pb = point_t(1.0_dp, 0.0_dp, 2, .true.)
-    pc = point_t(2.0_dp, 0.0_dp, 3, .true.)
-    
-    call assert_equal(orientation(pa, pb, pc), ORIENTATION_COLLINEAR, 'Collinear detection')
-    
-    ! Test very small triangle
-    pa = point_t(0.0_dp, 0.0_dp, 1, .true.)
-    pb = point_t(1e-15_dp, 0.0_dp, 2, .true.)
-    pc = point_t(0.0_dp, 1e-15_dp, 3, .true.)
-    
-    call assert_true(triangle_area(pa, pb, pc) < 1e-20_dp, 'Very small triangle area')
-    
-    call end_test()
-end subroutine
+        call assert_true(triangle_area(pa, pb, pc) < 1e-20_dp, 'Very small triangle area')
+
+        call end_test()
+    end subroutine
 
 
-! Helper subroutines and functions
+    ! Helper subroutines and functions
 
-subroutine start_test(test_name)
-    character(len=*), intent(in) :: test_name
-    test_count = test_count + 1
-    write(*,'(A,I0,A,A)') 'Test ', test_count, ': ', test_name
-end subroutine
+    subroutine start_test(test_name)
+        character(len=*), intent(in) :: test_name
+        test_count = test_count + 1
+        write(*,'(A,I0,A,A)') 'Test ', test_count, ': ', test_name
+    end subroutine
 
-subroutine end_test()
-    passed_tests = passed_tests + 1
-    write(*,*) '  PASSED'
-end subroutine
+    subroutine end_test()
+        passed_tests = passed_tests + 1
+        write(*,*) '  PASSED'
+    end subroutine
 
-subroutine assert_equal(actual, expected, description)
-    integer, intent(in) :: actual, expected
-    character(len=*), intent(in) :: description
-    if (actual /= expected) then
-        write(*,'(A,A,A,I0,A,I0)') '  FAILED: ', description, ' - got ', actual, ', expected ', expected
-        stop 1
-    end if
-end subroutine
+    subroutine assert_equal(actual, expected, description)
+        integer, intent(in) :: actual, expected
+        character(len=*), intent(in) :: description
+        if (actual /= expected) then
+            write(*,'(A,A,A,I0,A,I0)') '  FAILED: ', description, ' - got ', actual, ', expected ', expected
+            stop 1
+        end if
+    end subroutine
 
-subroutine assert_true(condition, description)
-    logical, intent(in) :: condition
-    character(len=*), intent(in) :: description
-    if (.not. condition) then
-        write(*,'(A,A)') '  FAILED: ', description
-        stop 1
-    end if
-end subroutine
+    subroutine assert_true(condition, description)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: description
+        if (.not. condition) then
+            write(*,'(A,A)') '  FAILED: ', description
+            stop 1
+        end if
+    end subroutine
 
-subroutine assert_false(condition, description)
-    logical, intent(in) :: condition
-    character(len=*), intent(in) :: description
-    if (condition) then
-        write(*,'(A,A)') '  FAILED: ', description
-        stop 1
-    end if
-end subroutine
+    subroutine assert_false(condition, description)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: description
+        if (condition) then
+            write(*,'(A,A)') '  FAILED: ', description
+            stop 1
+        end if
+    end subroutine
 
-subroutine assert_approx_equal(actual, expected, tolerance, description)
-    real(dp), intent(in) :: actual, expected, tolerance
-    character(len=*), intent(in) :: description
-    if (abs(actual - expected) > tolerance) then
-        write(*,'(A,A,A,ES15.8,A,ES15.8)') '  FAILED: ', description, ' - got ', actual, ', expected ', expected
-        stop 1
-    end if
-end subroutine
+    subroutine assert_approx_equal(actual, expected, tolerance, description)
+        real(dp), intent(in) :: actual, expected, tolerance
+        character(len=*), intent(in) :: description
+        if (abs(actual - expected) > tolerance) then
+            write(*,'(A,A,A,ES15.8,A,ES15.8)') '  FAILED: ', description, ' - got ', actual, ', expected ', expected
+            stop 1
+        end if
+    end subroutine
 
 end program test_triangulation_mephit

--- a/test/test_triangulation_units.f90
+++ b/test/test_triangulation_units.f90
@@ -7,15 +7,15 @@ program test_triangulation_units
     implicit none
 
     integer :: test_count = 0, passed_tests = 0
-    
+
     write(*,*) "=== Triangulation Unit Tests ==="
     write(*,*) ""
-    
+
     call test_simple_triangle_mesh()
     call test_edge_existence_check()
     call test_constraint_edge_insertion()
     call test_cavity_boundary_identification()
-    
+
     ! Summary
     write(*,*) ""
     write(*,'(A,I0,A,I0)') "Tests passed: ", passed_tests, "/", test_count
@@ -25,7 +25,7 @@ program test_triangulation_units
         write(*,*) "✗ Some tests failed!"
         stop 1
     end if
-    
+
 contains
 
     subroutine test_simple_triangle_mesh()
@@ -33,42 +33,42 @@ contains
         type(mesh_t) :: mesh
         real(dp) :: points(2, 3)
         integer, allocatable :: constraint_segments(:,:)
-        
+
         call start_test(test_name)
-        
+
         ! Create simple triangle: (0,0), (1,0), (0.5,1)
         points(:, 1) = [0.0_dp, 0.0_dp]
         points(:, 2) = [1.0_dp, 0.0_dp]
         points(:, 3) = [0.5_dp, 1.0_dp]
-        
+
         ! Should create exactly one triangle
         allocate(constraint_segments(2, 0))
         call constrained_delaunay_triangulate(points, constraint_segments, mesh)
-        
+
         call assert_true(mesh%npoints == 6, "Expected 6 vertices (3 real + 3 super-triangle)")
         call assert_true(mesh%ntriangles >= 1, "Expected at least 1 triangle")
         call assert_true(count_valid_triangles(mesh) == 1, "Expected exactly 1 valid triangle")
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_edge_existence_check()
         character(len=*), parameter :: test_name = "Edge Existence Check"
         type(mesh_t) :: mesh
         real(dp) :: points(2, 4)
         integer, allocatable :: constraint_segments(:,:)
-        
+
         call start_test(test_name)
-        
+
         ! Create square vertices
         points(:, 1) = [0.0_dp, 0.0_dp]
         points(:, 2) = [1.0_dp, 0.0_dp]
         points(:, 3) = [1.0_dp, 1.0_dp]
         points(:, 4) = [0.0_dp, 1.0_dp]
-        
+
         allocate(constraint_segments(2, 0))
         call constrained_delaunay_triangulate(points, constraint_segments, mesh)
-        
+
         ! Test edge existence functions (for 4-point square, vertices 4,5,6,7 are real points)
         ! We need to check what triangles actually exist
         write(*,*) "Debug: Valid triangles =", count_valid_triangles(mesh)
@@ -78,10 +78,10 @@ contains
         else
             call assert_true(.false., "No valid triangulation created")
         end if
-        
+
         call end_test()
     end subroutine
-    
+
     subroutine test_constraint_edge_insertion()
         character(len=*), parameter :: test_name = "Constraint Edge Insertion"
         type(mesh_t) :: mesh
@@ -120,7 +120,7 @@ contains
 
         call end_test()
     end subroutine
-    
+
     subroutine test_cavity_boundary_identification()
         character(len=*), parameter :: test_name = "Cavity Boundary Identification"
         type(mesh_t) :: mesh
@@ -128,31 +128,31 @@ contains
         integer, allocatable :: constraint_segments(:,:)
         integer, allocatable :: boundary_edges(:,:)
         integer :: nboundary
-        
+
         call start_test(test_name)
-        
+
         ! Create pentagon
         points(:, 1) = [0.0_dp, 0.0_dp]
         points(:, 2) = [1.0_dp, 0.0_dp]
         points(:, 3) = [1.5_dp, 1.0_dp]
         points(:, 4) = [0.5_dp, 1.5_dp]
         points(:, 5) = [-0.5_dp, 1.0_dp]
-        
+
         allocate(constraint_segments(2, 0))
         call constrained_delaunay_triangulate(points, constraint_segments, mesh)
-        
+
         ! Test that we can identify boundary edges
         ! (This tests internal boundary identification logic)
         call assert_true(mesh%ntriangles >= 3, "Pentagon should have at least 3 triangles")
-        
+
         call end_test()
     end subroutine
-    
+
     ! Helper functions
     function count_valid_triangles(mesh) result(count)
         type(mesh_t), intent(in) :: mesh
         integer :: count, i
-        
+
         count = 0
         do i = 1, mesh%ntriangles
             if (mesh%triangles(i)%valid) then
@@ -160,19 +160,19 @@ contains
             end if
         end do
     end function
-    
+
     ! Test framework helpers
     subroutine start_test(test_name)
         character(len=*), intent(in) :: test_name
         test_count = test_count + 1
         write(*,'(A,I0,A,A)') "Test ", test_count, ": ", test_name
     end subroutine
-    
+
     subroutine end_test()
         passed_tests = passed_tests + 1
         write(*,*) "  ✓ PASSED"
     end subroutine
-    
+
     subroutine assert_true(condition, description)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: description
@@ -181,7 +181,7 @@ contains
             stop 1
         end if
     end subroutine
-    
+
     subroutine assert_false(condition, description)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: description

--- a/test/test_vector_plotting.f90
+++ b/test/test_vector_plotting.f90
@@ -1,54 +1,54 @@
 program test_vector_plotting
-   use fortfem_kinds, only: dp
-   use fortfem_api, only: mesh_t, vector_function_space_t, &
-                          vector_trial_function_t, vector_test_function_t, vector_function_t, &
-                          vector_bc_t, form_expr_t, unit_square_mesh, vector_function_space, &
-                          vector_function, vector_trial_function, vector_test_function, &
-                          vector_bc, inner, curl, dx, solve, plot, operator(*), operator(==), &
-                          operator(+)
-   use check, only: check_condition, check_summary
-   implicit none
+    use fortfem_kinds, only: dp
+    use fortfem_api, only: mesh_t, vector_function_space_t, &
+        vector_trial_function_t, vector_test_function_t, vector_function_t, &
+        vector_bc_t, form_expr_t, unit_square_mesh, vector_function_space, &
+        vector_function, vector_trial_function, vector_test_function, &
+        vector_bc, inner, curl, dx, solve, plot, operator(*), operator(==), &
+        operator(+)
+    use check, only: check_condition, check_summary
+    implicit none
 
-   call test_vector_streamplot_output()
+    call test_vector_streamplot_output()
 
-   call check_summary("Vector plotting")
+    call check_summary("Vector plotting")
 
 contains
 
-   subroutine test_vector_streamplot_output()
-      type(mesh_t) :: mesh
-      type(vector_function_space_t) :: Vh
-      type(vector_trial_function_t) :: E
-      type(vector_test_function_t) :: F
-      type(vector_function_t) :: J, Eh
-      type(vector_bc_t) :: bc
-      type(form_expr_t) :: a, L
-      logical :: exists
-      character(len=*), parameter :: filename = &
-                                     "build/test_vector_plot.png"
+    subroutine test_vector_streamplot_output()
+        type(mesh_t) :: mesh
+        type(vector_function_space_t) :: Vh
+        type(vector_trial_function_t) :: E
+        type(vector_test_function_t) :: F
+        type(vector_function_t) :: J, Eh
+        type(vector_bc_t) :: bc
+        type(form_expr_t) :: a, L
+        logical :: exists
+        character(len=*), parameter :: filename = &
+            "build/test_vector_plot.png"
 
-      mesh = unit_square_mesh(4)
-      Vh = vector_function_space(mesh, "Nedelec", 1)
+        mesh = unit_square_mesh(4)
+        Vh = vector_function_space(mesh, "Nedelec", 1)
 
-      E = vector_trial_function(Vh)
-      F = vector_test_function(Vh)
-      J = vector_function(Vh)
-      J%values(:, 1) = 1.0_dp
-      J%values(:, 2) = 0.0_dp
+        E = vector_trial_function(Vh)
+        F = vector_test_function(Vh)
+        J = vector_function(Vh)
+        J%values(:, 1) = 1.0_dp
+        J%values(:, 2) = 0.0_dp
 
-      a = inner(curl(E), curl(F))*dx + inner(E, F)*dx
-      L = inner(J, F)*dx
+        a = inner(curl(E), curl(F))*dx + inner(E, F)*dx
+        L = inner(J, F)*dx
 
-      bc = vector_bc(Vh, [0.0_dp, 0.0_dp], "tangential")
-      Eh = vector_function(Vh)
+        bc = vector_bc(Vh, [0.0_dp, 0.0_dp], "tangential")
+        Eh = vector_function(Vh)
 
-      call solve(a == L, Eh, bc)
+        call solve(a == L, Eh, bc)
 
-      call plot(Eh, filename=filename, title="Vector FEM Solution", &
-                plot_type="streamplot")
+        call plot(Eh, filename=filename, title="Vector FEM Solution", &
+            plot_type="streamplot")
 
-      inquire (file=filename, exist=exists)
-      call check_condition(exists, "Vector plot creates output file")
-   end subroutine test_vector_streamplot_output
+        inquire (file=filename, exist=exists)
+        call check_condition(exists, "Vector plot creates output file")
+    end subroutine test_vector_streamplot_output
 
 end program test_vector_plotting

--- a/test_plot.f90
+++ b/test_plot.f90
@@ -1,15 +1,15 @@
 program test_plot
     use fortplot
     implicit none
-    
+
     real(8) :: x(4), y(4)
-    
+
     x = [0.0d0, 1.0d0, 1.0d0, 0.0d0]
     y = [0.0d0, 0.0d0, 1.0d0, 1.0d0]
-    
+
     call figure()
     call plot(x, y)
     call savefig("test.png")
-    
+
     print *, "Test completed"
 end program test_plot


### PR DESCRIPTION
Format all Fortran sources with `fo fmt` native style (88 col, 4 space indent). Pure reformatting: `git diff -w` empty (3629/3629, 87 files). `fo build` link error is the pre-existing missing `umfpack` library, unrelated to formatting.