### PR TITLE
docs: record ffc 8a43a3c DIMENSION handoff

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,10 +13,13 @@ has a successful Ubuntu job while Windows remains in progress with the known
 portability set. The current-main push [31144447791](https://github.com/lazy-fortran/fortfront/actions/runs/31144447791)
 is also still in progress, so no aggregate FortFront PASS is claimed here.
 
-The current ffc compiler-path pin is `7dc6059`, which includes typed ISO C
-pointer extraction `aab7ef9` and the rebased integer(8)/descriptor dispatch
-guard. ffc is not a FortFEM build dependency; this line records the exact
-cross-repository handoff only, and its aggregate suite remains open.
+The current ffc compiler-path pin is `8a43a3c`, which includes typed ISO C
+pointer extraction `aab7ef9`, the rebased integer(8)/descriptor dispatch
+guard, and the bare-DIMENSION #2848 fix. Its independent gfortran-backed
+`issue_2848_dimension_statement` gauntlet is PASS=1/XFAIL=0/XPASS=0/FAIL=0;
+only that now-green XFAIL row was removed. ffc is not a FortFEM build
+dependency; this line records the exact cross-repository handoff only, and
+its aggregate suite remains open.
 
 The former source-discovery and continuation-lexer blockers were closed at
 the older `193457a9`/`2179929e` snapshot. The completed aggregate run


### PR DESCRIPTION
Docs-only ffc handoff update: pins 8a43a3c and records the independent #2848 PASS with its single XFAIL removal. No source or local suite changes.