### PR TITLE
docs: repin repaired ffc handoff

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ has a successful Ubuntu job, including the #2975 nested-associate owner-boundary
 regression. Windows retains the documented nine-test portability baseline, so
 no aggregate FortFront PASS is claimed here.
 
-The current ffc compiler-path pin is `de04a46`, documented at `1cd5492`.
+The current ffc compiler-path pin is `fc3ea15`, documented at `f13906b`.
 It includes typed ISO C-pointer, inferred-symbol, TRANSFER, rank-1 deep-copy,
 integer, BLOCK/DO CONCURRENT, DO WHILE, GOTO, FORALL, WHERE, and SELECT
 lowering extraction, the integer(8) external-call guard, bare-DIMENSION #2848,
@@ -22,13 +22,13 @@ and GCC14-safe descendant exports. The FORALL/WHERE focused oracles cover
 masked assignment, ELSEWHERE, reductions, and rank behavior; SELECT covers
 case/default, type, rank, runtime, and derived dispatch. The production
 inventory is now 54 `.inc` files (70,951 lines), down from the pre-wave
-snapshot. Focused structured-control, integer, and gfortran differential/link
-oracles pass locally. Aggregate clean-build validation is not claimed: the
-current ffc CI cold-link check reports twelve unresolved WHERE-submodule host
-exports pending the corresponding repair. The ffc pull-request formatter and
-full-suite jobs also retain their known baseline failures/cancellation, and no
-aggregate corpus PASS is claimed. ffc is not a FortFEM build dependency; this
-line records the exact cross-repository handoff only.
+snapshot. The repaired current-head gate is a local cold `fo clean && fo build`
+at 453/453; five focused compiler tests pass, and independent gfortran
+differentials produce exact WHERE output `2 3 30 40` and SELECT output `27`.
+The earlier WHERE cold-link defect is repaired by the host exports in `fc3ea15`;
+the PR aggregate CI and formatter/full-suite baseline remain separate observed
+gates, so no aggregate corpus PASS is claimed. ffc is not a FortFEM build
+dependency; this line records the exact cross-repository handoff only.
 
 The former source-discovery and continuation-lexer blockers were closed at
 the older `193457a9`/`2179929e` snapshot. The completed aggregate run


### PR DESCRIPTION
Repin the cross-repository ffc handoff to code `fc3ea15` and roadmap docs `f13906b` after the WHERE host-export repair (#723/#724).

Record the local cold `fo clean && fo build` 453/453 gate, five focused compiler PASSes, and exact independent gfortran outputs for WHERE and SELECT. Aggregate corpus PASS remains explicitly unclaimed. Docs-only; no FortFEM code changes.